### PR TITLE
ci: pin github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(ci)
+    groups:
+      dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/enforce-sha.yaml
+++ b/.github/workflows/enforce-sha.yaml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 name: Security
 
@@ -12,4 +15,4 @@ jobs:
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633 # v3
         with:
           allowlist: |
-            - prefix-dev/
+            prefix-dev/

--- a/.github/workflows/enforce-sha.yaml
+++ b/.github/workflows/enforce-sha.yaml
@@ -1,0 +1,15 @@
+on: push
+
+name: Security
+
+jobs:
+  ensure-pinned-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633 # v3
+        with:
+          allowlist: |
+            - prefix-dev/

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,7 +9,7 @@ jobs:
   run_tests:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
         - uses: prefix-dev/setup-pixi@v0.8.1
           with:
@@ -23,7 +23,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:

--- a/.github/workflows/update_bioconda.yml
+++ b/.github/workflows/update_bioconda.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
         string_list: ${{ steps.generate.outputs.string_list }}
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         - uses: prefix-dev/setup-pixi@v0.8.1
 
         - name: Generate combination of missing subdirs and letters
@@ -37,7 +37,7 @@ jobs:
             R2_PREFIX_BUCKET: ${{ secrets.R2_PREFIX_BUCKET }}
 
         - name: Upload requested index.json
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
           with:
             name: index
             path: output_index
@@ -51,11 +51,11 @@ jobs:
             subdirs: ${{fromJson(needs.generate_hash_letters.outputs.string_list)}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1
 
       - name: Get partial index artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
             name: index
             path: output_index
@@ -69,7 +69,7 @@ jobs:
             R2_PREFIX_BUCKET: ${{ secrets.R2_PREFIX_BUCKET }}
 
       - name: Upload partial index
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
             name: partial_index_${{ matrix.subdirs }}
             path: output
@@ -78,11 +78,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: updater_of_records
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         - uses: prefix-dev/setup-pixi@v0.8.1
 
         - name: Get partial index artifacts
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
           with:
             merge-multiple: true
             path: output
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - uses: prefix-dev/setup-pixi@v0.8.1
 

--- a/.github/workflows/update_pytorch.yml
+++ b/.github/workflows/update_pytorch.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
         string_list: ${{ steps.generate.outputs.string_list }}
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         - uses: prefix-dev/setup-pixi@v0.8.1
 
         - name: Generate combination of missing subdirs and letters
@@ -37,7 +37,7 @@ jobs:
             R2_PREFIX_BUCKET: ${{ secrets.R2_PREFIX_BUCKET }}
 
         - name: Upload requested index.json
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
           with:
             name: index
             path: output_index
@@ -51,11 +51,11 @@ jobs:
             subdirs: ${{fromJson(needs.generate_hash_letters.outputs.string_list)}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1
 
       - name: Get partial index artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
             name: index
             path: output_index
@@ -69,7 +69,7 @@ jobs:
             R2_PREFIX_BUCKET: ${{ secrets.R2_PREFIX_BUCKET }}
 
       - name: Upload partial index
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
             name: partial_index_${{ matrix.subdirs }}
             path: output
@@ -78,11 +78,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: updater_of_records
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         - uses: prefix-dev/setup-pixi@v0.8.1
 
         - name: Get partial index artifacts
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
           with:
             merge-multiple: true
             path: output
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - uses: prefix-dev/setup-pixi@v0.8.1
 

--- a/.github/workflows/updater_conda_forge.yml
+++ b/.github/workflows/updater_conda_forge.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
         string_list: ${{ steps.generate.outputs.string_list }}
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         - uses: prefix-dev/setup-pixi@v0.8.1
 
         - name: Generate combination of missing subdirs and letters
@@ -33,7 +33,7 @@ jobs:
             R2_PREFIX_BUCKET: ${{ secrets.R2_PREFIX_BUCKET }}
 
         - name: Upload requested index.json
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
           with:
             name: index
             path: output_index
@@ -47,11 +47,11 @@ jobs:
             subdirs: ${{fromJson(needs.generate_hash_letters.outputs.string_list)}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1
 
       - name: Get partial index artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
             name: index
             path: output_index
@@ -65,7 +65,7 @@ jobs:
             R2_PREFIX_BUCKET: ${{ secrets.R2_PREFIX_BUCKET }}
 
       - name: Upload partial index
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
             name: partial_index_${{ matrix.subdirs }}
             path: output
@@ -74,11 +74,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: updater_of_records
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         - uses: prefix-dev/setup-pixi@v0.8.1
 
         - name: Get partial index artifacts
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
           with:
             merge-multiple: true
             path: output
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: prefix-dev/setup-pixi@v0.8.1
 
       - name: Update grayskull mapping and compressed mapping


### PR DESCRIPTION
- pin external actions
- enforce sha also in the future

For motivation see https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised and https://michaelheap.com/pin-your-github-actions/