### PR TITLE
feat: better regex for matching .dist-info folders and adds invaldate

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1,46 +1,26 @@
-version: 6
+version: 7
+platforms:
+- name: linux-64
+- name: osx-arm64
+- name: win-64
 environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.2-py312h27b7581_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312h67db365_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312hee9fe19_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/docker-compose-5.0.0-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
@@ -55,44 +35,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.3-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel-1.0-py312h7900ff3_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
@@ -100,29 +51,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.22.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
-      - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
-      - pypi: ./
-      osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.2-py312he52fbff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -131,23 +63,122 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312hcae0c51_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.3-py312h05a80bc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docker-compose-5.0.0-h4bfb45e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - pypi: .
+      - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
+      - pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.2-py312he52fbff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312hcae0c51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.3-py312h05a80bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docker-compose-5.0.0-h4bfb45e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.5-hf598326_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
@@ -155,44 +186,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.0-h8adb53f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.6.3-py312hdb8e49c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py312h998013c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel-1.0-py312h81bd7bf_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py312h163523d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_2.conda
@@ -200,29 +202,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.22.0-py312h5748b74_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py312h37e1c23_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: .
       - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.2-py312h927b8db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -231,52 +232,33 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312h9d5906e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-46.0.3-py312h84d000f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/docker-compose-5.0.0-h6a83c73_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.7.0-py312hfdf67e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.3-py312h05f76fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py312h31fea79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.41.5-py312hdabe01f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel-1.0-py312h2e8e312_11.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
@@ -287,81 +269,73 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.2-py312h927b8db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312h9d5906e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-46.0.3-py312h84d000f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/docker-compose-5.0.0-h6a83c73_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.7.0-py312hfdf67e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.3-py312h05f76fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py312h31fea79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.41.5-py312hdabe01f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel-1.0-py312h2e8e312_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.3-py312he06e257_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.8.1-h208afaa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.8.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.22.0-py312h05f76fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: .
       - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
   fmt:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.2-py312h27b7581_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312h67db365_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312hee9fe19_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/docker-compose-5.0.0-h280c20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
@@ -376,60 +350,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.3-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.18.2-py312h4c3975b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-hooks-4.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.3-py312h5253ce2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel-1.0-py312h7900ff3_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.16-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.14-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.5.7-py312hbe4c86d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.39.1-hdab8a38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312hd9148b4_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
@@ -438,27 +375,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.22.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
-      - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
-      - pypi: ./
-      osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.2-py312he52fbff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -467,72 +387,43 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312hcae0c51_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.3-py312h05a80bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docker-compose-5.0.0-h4bfb45e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.5-hf598326_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.0-h8adb53f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.6.3-py312hdb8e49c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.18.2-py312h4409184_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-hooks-4.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py312h998013c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.1.3-py312h37e1c23_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h5748b74_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel-1.0-py312h81bd7bf_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.16-py312h4409184_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.14-py312h4409184_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.5.7-py312h3402d49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
@@ -543,12 +434,121 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.39.1-hd1458d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312ha0dd364_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - pypi: .
+      - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
+      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-hooks-4.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.2-py312he52fbff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312hcae0c51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.3-py312h05a80bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docker-compose-5.0.0-h4bfb45e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.5-hf598326_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.0-h8adb53f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.6.3-py312hdb8e49c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.18.2-py312h4409184_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py312h998013c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.1.3-py312h37e1c23_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h5748b74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel-1.0-py312h81bd7bf_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.16-py312h4409184_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.14-py312h4409184_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.5.7-py312h3402d49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.39.1-hd1458d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312ha0dd364_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py312h163523d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_2.conda
@@ -557,27 +557,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.22.0-py312h5748b74_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py312h37e1c23_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: .
       - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.2-py312h927b8db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -586,68 +585,43 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312h9d5906e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-46.0.3-py312h84d000f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/docker-compose-5.0.0-h6a83c73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.7.0-py312hfdf67e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.3-py312h05f76fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.18.2-py312he06e257_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-hooks-4.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py312h31fea79_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.1.3-py312he5662c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.41.5-py312hdabe01f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py312h05f76fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel-1.0-py312h2e8e312_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.16-py312he06e257_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.14-py312he06e257_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.5.7-py312h7a6832a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
@@ -658,17 +632,43 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.39.1-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py312hf90b1b7_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.2-py312h927b8db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312h9d5906e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-46.0.3-py312h84d000f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/docker-compose-5.0.0-h6a83c73_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.7.0-py312hfdf67e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.3-py312h05f76fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.18.2-py312he06e257_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py312h31fea79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.1.3-py312he5662c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.41.5-py312hdabe01f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py312h05f76fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel-1.0-py312h2e8e312_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.16-py312he06e257_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.14-py312he06e257_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.5.7-py312h7a6832a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.39.1-h77a83cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py312hf90b1b7_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.3-py312he06e257_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.8.1-h208afaa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.8.1-h2466b09_2.conda
@@ -676,64 +676,38 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.22.0-py312h05f76fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: .
       - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
   test:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.2-py312h27b7581_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312h67db365_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312hee9fe19_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/docker-compose-5.0.0-h280c20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
@@ -748,50 +722,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.3-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel-1.0-py312h7900ff3_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.16-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.14-py312h4c3975b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
@@ -800,34 +742,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.22.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
-      - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/83/d4/6991df072b34741a0c115e8d21dc2fe142e4b497319d762e957f6677f001/moto-5.1.18-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/20/69a0e6058bc5ea74892d089d64dfc3a62ba78917ec5e2cfa70f7c92ba3a5/xmltodict-1.0.2-py3-none-any.whl
-      - pypi: ./
-      osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.2-py312he52fbff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -836,63 +754,37 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312hcae0c51_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.3-py312h05a80bc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docker-compose-5.0.0-h4bfb45e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.5-hf598326_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.0-h8adb53f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.6.3-py312hdb8e49c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py312h998013c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h5748b74_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel-1.0-py312h81bd7bf_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.16-py312h4409184_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.14-py312h4409184_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
@@ -906,6 +798,112 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - pypi: .
+      - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
+      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/83/d4/6991df072b34741a0c115e8d21dc2fe142e4b497319d762e957f6677f001/moto-5.1.18-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c0/20/69a0e6058bc5ea74892d089d64dfc3a62ba78917ec5e2cfa70f7c92ba3a5/xmltodict-1.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.2-py312he52fbff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312hcae0c51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.3-py312h05a80bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docker-compose-5.0.0-h4bfb45e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.5-hf598326_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.0-h8adb53f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.6.3-py312hdb8e49c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py312h998013c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h5748b74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel-1.0-py312h81bd7bf_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.16-py312h4409184_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.14-py312h4409184_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py312h163523d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_2.conda
@@ -914,34 +912,33 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.22.0-py312h5748b74_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py312h37e1c23_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: .
       - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/83/d4/6991df072b34741a0c115e8d21dc2fe142e4b497319d762e957f6677f001/moto-5.1.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/83/d4/6991df072b34741a0c115e8d21dc2fe142e4b497319d762e957f6677f001/moto-5.1.18-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/20/69a0e6058bc5ea74892d089d64dfc3a62ba78917ec5e2cfa70f7c92ba3a5/xmltodict-1.0.2-py3-none-any.whl
-      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.2-py312h927b8db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -950,59 +947,37 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312h9d5906e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-46.0.3-py312h84d000f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/docker-compose-5.0.0-h6a83c73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.7.0-py312hfdf67e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.3-py312h05f76fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py312h31fea79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.41.5-py312hdabe01f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py312h05f76fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel-1.0-py312h2e8e312_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.16-py312he06e257_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.14-py312he06e257_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
@@ -1014,13 +989,36 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.2-py312h927b8db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312h9d5906e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-46.0.3-py312h84d000f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/docker-compose-5.0.0-h6a83c73_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.7.0-py312hfdf67e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.3-py312h05f76fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py312h31fea79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.41.5-py312hdabe01f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py312h05f76fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel-1.0-py312h2e8e312_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.16-py312he06e257_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.14-py312he06e257_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.3-py312he06e257_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.8.1-h208afaa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.8.1-h2466b09_2.conda
@@ -1028,69 +1026,45 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.22.0-py312h05f76fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: .
       - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/83/d4/6991df072b34741a0c115e8d21dc2fe142e4b497319d762e957f6677f001/moto-5.1.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/83/d4/6991df072b34741a0c115e8d21dc2fe142e4b497319d762e957f6677f001/moto-5.1.18-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/20/69a0e6058bc5ea74892d089d64dfc3a62ba78917ec5e2cfa70f7c92ba3a5/xmltodict-1.0.2-py3-none-any.whl
-      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
   type-checking:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.2-py312h27b7581_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312h67db365_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312hee9fe19_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/docker-compose-5.0.0-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
@@ -1105,51 +1079,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.3-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.18.2-py312h4c3975b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.3-py312h5253ce2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel-1.0-py312h7900ff3_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-deprecated-1.2.15.20250304-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.20240406-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
@@ -1157,29 +1097,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.22.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
-      - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
-      - pypi: ./
-      osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.2-py312he52fbff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -1188,23 +1109,132 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312hcae0c51_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.3-py312h05a80bc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docker-compose-5.0.0-h4bfb45e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-deprecated-1.2.15.20250304-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.20240406-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - pypi: .
+      - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
+      - pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-deprecated-1.2.15.20250304-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.20240406-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.2-py312he52fbff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312hcae0c51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.3-py312h05a80bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docker-compose-5.0.0-h4bfb45e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.5-hf598326_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
@@ -1212,51 +1242,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.0-h8adb53f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.6.3-py312hdb8e49c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.18.2-py312h4409184_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py312h998013c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.1.3-py312h37e1c23_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel-1.0-py312h81bd7bf_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.4-haa4fddc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-deprecated-1.2.15.20250304-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.20240406-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py312h163523d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_2.conda
@@ -1264,29 +1260,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.22.0-py312h5748b74_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py312h37e1c23_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: .
       - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.2-py312h927b8db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -1295,56 +1290,35 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.162-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.40.72-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312h9d5906e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-46.0.3-py312h84d000f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/docker-compose-5.0.0-h6a83c73_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.7.0-py312hfdf67e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.3-py312h05f76fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.18.2-py312he06e257_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py312h31fea79_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.1.3-py312he5662c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.4-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.41.5-py312hdabe01f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel-1.0-py312h2e8e312_11.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.4-pyh9571d03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.4-pyhe01879c_0.conda
@@ -1358,36 +1332,58 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.2-py312h927b8db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312h9d5906e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-46.0.3-py312h84d000f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/docker-compose-5.0.0-h6a83c73_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.7.0-py312hfdf67e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.3-py312h05f76fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.18.2-py312he06e257_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py312h31fea79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.1.3-py312he5662c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.41.5-py312hdabe01f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel-1.0-py312h2e8e312_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.3-py312he06e257_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.8.1-h208afaa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.8.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.22.0-py312h05f76fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
-      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+      - pypi: .
       - pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -1410,6 +1406,645 @@ packages:
   purls: []
   size: 23621
   timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.2-py312h27b7581_0.conda
+  sha256: baf2bbf52aeecdbfe6e03a373b2664169cbdc37a92a2ac68bc7ef45353f65d61
+  md5: ad84ca57d502eead2df0233090261dfb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aiohappyeyeballs >=2.5.0
+  - aiosignal >=1.4.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - libgcc >=14
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/aiohttp?source=hash-mapping
+  size: 1014925
+  timestamp: 1761727721839
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312h67db365_0.conda
+  sha256: 1acccd5464d81184ead80c017b4a7320c59c2774eb914f14d60ca8b4c55754e9
+  md5: 7c9245551ebbe6b6068aeda04060afaa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - libbrotlicommon 1.2.0 h09219d5_0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
+  size: 367744
+  timestamp: 1761592371750
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+  sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
+  md5: 51a19bba1b8ebfb60df25cde030b7ebc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 260341
+  timestamp: 1757437258798
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
+  sha256: 7dafe8173d5f94e46cf9cd597cc8ff476a8357fbbd4433a8b5697b2864845d9c
+  md5: 648ee28dcd4e07a1940a17da62eccd40
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  size: 295716
+  timestamp: 1761202958833
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312hee9fe19_0.conda
+  sha256: 3b158c55cb494a5da669465ff86c774b2e65f0c8541a888aae970fb7a74aeb58
+  md5: 85ce285422e464eb1768aefd7d0d89f0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.14
+  - libgcc >=14
+  - openssl >=3.5.4,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=compressed-mapping
+  size: 1716207
+  timestamp: 1760605051655
+- conda: https://conda.anaconda.org/conda-forge/linux-64/docker-compose-5.0.0-h280c20c_0.conda
+  sha256: 69f3b15197189fd6ee23999f4bd4c9ff3e29a92a039ee3099616a64d7ad7ae53
+  md5: 942ae0eb872a6ea7b3bd2e08983852d1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 9416022
+  timestamp: 1764757749451
+- conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
+  sha256: f4e0e6cd241bc24afb2d6d08e5d2ba170fad2475e522bdf297b7271bba268be6
+  md5: 63e20cf7b7460019b423fc06abb96c60
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/frozenlist?source=hash-mapping
+  size: 55037
+  timestamp: 1752167383781
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12129203
+  timestamp: 1720853576813
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_5.conda
+  sha256: dab1fbf65abb05d3f2ee49dff90d60eeb2e02039fcb561343c7cea5dea523585
+  md5: 511ed8935448c1875776b60ad3daf3a1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.44
+  license: GPL-3.0-only
+  purls: []
+  size: 741516
+  timestamp: 1762674665675
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
+  sha256: da2080da8f0288b95dd86765c801c6e166c4619b910b11f9a8446fb852438dc2
+  md5: 4211416ecba1866fab0c6470986c22d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 74811
+  timestamp: 1752719572741
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
+  sha256: 25cbdfa65580cfab1b8d15ee90b4c9f1e0d72128f1661449c9a999d341377d54
+  md5: 35f29eec58405aaf55e01cb470d8c26a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 57821
+  timestamp: 1760295480630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
+  sha256: 08f9b87578ab981c7713e4e6a7d935e40766e10691732bba376d4964562bcb45
+  md5: c0374badb3a5d4b1372db28d19462c53
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 15.2.0 h767d61c_7
+  - libgcc-ng ==15.2.0=*_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 822552
+  timestamp: 1759968052178
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
+  sha256: 2045066dd8e6e58aaf5ae2b722fb6dfdbb57c862b5f34ac7bfb58c40ef39b6ad
+  md5: 280ea6eee9e2ddefde25ff799c4f0363
+  depends:
+  - libgcc 15.2.0 h767d61c_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 29313
+  timestamp: 1759968065504
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
+  sha256: e9fb1c258c8e66ee278397b5822692527c5f5786d372fe7a869b900853f3f5ca
+  md5: f7b4d76975aac7e5d9e6ad13845f92fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 447919
+  timestamp: 1759967942498
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+  sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
+  md5: 1a580f7796c7bf6393fddb8bbbde58dc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  purls: []
+  size: 112894
+  timestamp: 1749230047870
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_2.conda
+  sha256: 329e66330a8f9cbb6a8d5995005478188eb4ba8a6b6391affa849744f4968492
+  md5: f61edadbb301530bd65a32646bd81552
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_2
+  license: 0BSD
+  purls: []
+  size: 439868
+  timestamp: 1749230061968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+  md5: d864d34357c3b65a4b731f78c0801dc4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  license_family: GPL
+  purls: []
+  size: 33731
+  timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
+  sha256: 4c992dcd0e34b68f843e75406f7f303b1b97c248d18f3c7c330bdc0bc26ae0b3
+  md5: 729a572a3ebb8c43933b30edcc628ceb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  purls: []
+  size: 945576
+  timestamp: 1762299687230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
+  sha256: 1b981647d9775e1cdeb2fab0a4dd9cd75a6b0de2963f6c3953dbd712f78334b3
+  md5: 5b767048b1b3ee9a954b06f4084f93dc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 h767d61c_7
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 3898269
+  timestamp: 1759968103436
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
+  sha256: 024fd46ac3ea8032a5ec3ea7b91c4c235701a8bf0e6520fe5e6539992a6bd05f
+  md5: f627678cf829bd70bccf141a19c3ad3e
+  depends:
+  - libstdcxx 15.2.0 h8f9b012_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 29343
+  timestamp: 1759968157195
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
+  sha256: e5ec6d2ad7eef538ddcb9ea62ad4346fde70a4736342c4ad87bd713641eb9808
+  md5: 80c07c68d2f6870250959dcc95b209d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 37135
+  timestamp: 1758626800002
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.3-py312h178313f_0.conda
+  sha256: c703d148a85ffb4f11001d31b7c4c686a46ad554eeeaa02c69da59fbf0e00dbb
+  md5: f4e246ec4ccdf73e50eefb0fa359a64e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/multidict?source=hash-mapping
+  size: 97272
+  timestamp: 1751310833783
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.18.2-py312h4c3975b_0.conda
+  sha256: fb90735bc355263cde3b3af4fff62dafa9d14b0aacb46f644c8ea7e82a9fd133
+  md5: 25163f59343531e356658848bde3fc7c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - mypy_extensions >=1.0.0
+  - pathspec >=0.9.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.6.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mypy?source=hash-mapping
+  size: 19541793
+  timestamp: 1758278722332
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+  sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
+  md5: 47e340acb35de30501a76c7c799c41d7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 891641
+  timestamp: 1738195959188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
+  sha256: a47271202f4518a484956968335b2521409c8173e123ab381e775c358c67fe6d
+  md5: 9ee58d5c534af06558933af3c845a780
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3165399
+  timestamp: 1762839186699
+- conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
+  sha256: d0ff67d89cf379a9f0367f563320621f0bc3969fe7f5c85e020f437de0927bb4
+  md5: 0cf580c1b73146bb9ff1bbdb4d4c8cf9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/propcache?source=hash-mapping
+  size: 54233
+  timestamp: 1744525107433
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.3-py312h5253ce2_0.conda
+  sha256: 1b679202ebccf47be64509a4fc2a438a66229403257630621651b2886b882597
+  md5: 82ce56c5a4a55165aed95e04923ab363
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
+  size: 495011
+  timestamp: 1762092914381
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+  sha256: 07f899d035e06598682d3904d55f1529fac71b15e12b61d44d6a5fbf8521b0fe
+  md5: 56a776330a7d21db63a7c9d6c3711a04
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=compressed-mapping
+  size: 1935221
+  timestamp: 1762989004359
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
+  sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
+  md5: 7f97faab5bebcc2580f4f299285323da
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.0,<2.1.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 32123473
+  timestamp: 1696324522323
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_0.conda
+  sha256: 1b3dc4c25c83093fff08b86a3574bc6b94ba355c8eba1f35d805c5e256455fc7
+  md5: fba10c2007c8b06f77c5a23ce3a635ad
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 204539
+  timestamp: 1758892248166
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+  sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
+  md5: 283b96675859b20a825f8fa30f311446
+  depends:
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 282480
+  timestamp: 1740379431762
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel-1.0-py312h7900ff3_11.conda
+  sha256: 338e94c880a467b6a276fbcf7cd770001d7b150e3cecae8237568c3e654d56e7
+  md5: d64200afbf154191e1414daf612b22e7
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 7409
+  timestamp: 1762507229125
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.16-py312h4c3975b_0.conda
+  sha256: c792402cccee6a6dc01ad1451621e3ca002d72208ee28a33dc8594a19e3f7504
+  md5: 04c3560d6229bdfc73fc97586d8fe1a6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ruamel.yaml.clib >=0.1.2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml?source=hash-mapping
+  size: 269849
+  timestamp: 1761160693733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.14-py312h4c3975b_0.conda
+  sha256: 4c3c9311590f1ca072ac956aa2df712600a385ffc52e90982ebfc84da8db31c3
+  md5: b59f191f3cd25057889dbe91e1387231
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
+  size: 138966
+  timestamp: 1760564285617
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.5.7-py312hbe4c86d_0.conda
+  sha256: b8cc83042471c5740f29a5f3ce1ef7116b892095591907929671fe4e33345026
+  md5: 8871e1b8e5ec1c57d3769adc0b9e5d68
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruff?source=hash-mapping
+  size: 7184746
+  timestamp: 1723150552013
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+  sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
+  md5: a0116df4f4ed05c303811a837d5b39d8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3285204
+  timestamp: 1748387766691
+- conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.39.1-hdab8a38_0.conda
+  sha256: 1d46b85459276f0ff5d25eaf7d4c4b7434580f41f6748505376791d3894777e4
+  md5: ae3ecc640ffae55a243aba57f4a34060
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 3360083
+  timestamp: 1762998892995
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312hd9148b4_6.conda
+  sha256: e1ecdfe8b0df725436e1d307e8672010d92b9aa96148f21ddf9be9b9596c75b0
+  md5: f30ece80e76f9cc96e30cc5c71d2818e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
+  size: 14602
+  timestamp: 1761594857801
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
+  sha256: 8320d5af37eb8933e5d129884ea013b2687e75b08aff5216193df3378eaea92f
+  md5: 8af3faf88325836e46c6cb79828e058c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/wrapt?source=hash-mapping
+  size: 64608
+  timestamp: 1756851740646
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
+  sha256: 802725371682ea06053971db5b4fb7fbbcaee9cb1804ec688f55e51d74660617
+  md5: 68eae977d7d1196d32b636a026dc015d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_2
+  - liblzma-devel 5.8.1 hb9d3cd8_2
+  - xz-gpl-tools 5.8.1 hbcc6ac9_2
+  - xz-tools 5.8.1 hb9d3cd8_2
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
+  size: 23987
+  timestamp: 1749230104359
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
+  sha256: 840838dca829ec53f1160f3fca6dbfc43f2388b85f15d3e867e69109b168b87b
+  md5: bf627c16aa26231720af037a2709ab09
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_2
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
+  size: 33911
+  timestamp: 1749230090353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
+  sha256: 58034f3fca491075c14e61568ad8b25de00cb3ae479de3e69be6d7ee5d3ace28
+  md5: 1bad2995c8f1c8075c6c331bf96e46fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_2
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later
+  purls: []
+  size: 96433
+  timestamp: 1749230076687
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+  sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
+  md5: a77f85f77be52ff59391544bfe73390a
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 85189
+  timestamp: 1753484064210
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.22.0-py312h8a5da7c_0.conda
+  sha256: 6e3f2db09387fc982b5400b842745084825cd2d4621e8278e4af8fb0dc2b55d8
+  md5: 6a3fd177315aaafd4366930d440e4430
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - idna >=2.0
+  - libgcc >=14
+  - multidict >=4.0
+  - propcache >=0.2.1
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/yarl?source=hash-mapping
+  size: 151549
+  timestamp: 1761337128623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
+  sha256: c2bcb8aa930d6ea3c9c7a64fc4fab58ad7bcac483a9a45de294f67d2f447f413
+  md5: 02738ff9855946075cbd1b5274399a41
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  purls:
+  - pkg:pypi/zstandard?source=compressed-mapping
+  size: 467133
+  timestamp: 1762512686069
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+  sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
+  md5: 6432cb5d4ac0046c3ac0a8a0f95842f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 567578
+  timestamp: 1742433379869
 - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-13.2.0-pyhd8ed1ab_1.conda
   sha256: 8dfc64e24cacec22c2a4f6e2da65292c485f42001d9a486360e9320672a551a0
   md5: 3ee9ab5469f7ecc042fbddf073405924
@@ -1463,70 +2098,6 @@ packages:
   - pkg:pypi/aiohappyeyeballs?source=hash-mapping
   size: 19750
   timestamp: 1741775303303
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.2-py312h27b7581_0.conda
-  sha256: baf2bbf52aeecdbfe6e03a373b2664169cbdc37a92a2ac68bc7ef45353f65d61
-  md5: ad84ca57d502eead2df0233090261dfb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - aiohappyeyeballs >=2.5.0
-  - aiosignal >=1.4.0
-  - attrs >=17.3.0
-  - frozenlist >=1.1.1
-  - libgcc >=14
-  - multidict >=4.5,<7.0
-  - propcache >=0.2.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - yarl >=1.17.0,<2.0
-  license: MIT AND Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/aiohttp?source=hash-mapping
-  size: 1014925
-  timestamp: 1761727721839
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.2-py312he52fbff_0.conda
-  sha256: 390d41a479791835dcb24631661d28892bd2b1c8dc5ad3c86612b44e02204508
-  md5: b4abb46248fa5cf1bc71c1b837c648a8
-  depends:
-  - __osx >=11.0
-  - aiohappyeyeballs >=2.5.0
-  - aiosignal >=1.4.0
-  - attrs >=17.3.0
-  - frozenlist >=1.1.1
-  - multidict >=4.5,<7.0
-  - propcache >=0.2.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - yarl >=1.17.0,<2.0
-  license: MIT AND Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/aiohttp?source=hash-mapping
-  size: 985894
-  timestamp: 1761727100703
-- conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.2-py312h927b8db_0.conda
-  sha256: 81391f625cac7dc7b336bfa4204d8b07371c593a72f1766886591434793f17aa
-  md5: 21bb8466e377d3d952a48a95dd52dbad
-  depends:
-  - aiohappyeyeballs >=2.5.0
-  - aiosignal >=1.4.0
-  - attrs >=17.3.0
-  - frozenlist >=1.1.1
-  - multidict >=4.5,<7.0
-  - propcache >=0.2.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - yarl >=1.17.0,<2.0
-  license: MIT AND Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/aiohttp?source=hash-mapping
-  size: 960833
-  timestamp: 1761726896002
 - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
   sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
   md5: 3eb47adbffac44483f59e580f8600a1e
@@ -1575,19 +2146,6 @@ packages:
   - pkg:pypi/attrs?source=hash-mapping
   size: 60101
   timestamp: 1759762331492
-- pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
-  name: beautifulsoup4
-  version: 4.14.3
-  sha256: 0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb
-  requires_dist:
-  - soupsieve>=1.6.1
-  - typing-extensions>=4.0.0
-  - cchardet ; extra == 'cchardet'
-  - chardet ; extra == 'chardet'
-  - charset-normalizer ; extra == 'charset-normalizer'
-  - html5lib ; extra == 'html5lib'
-  - lxml ; extra == 'lxml'
-  requires_python: '>=3.7.0'
 - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
   sha256: cf90e13146b5d143a749c68a0550b6ddd0e1e0d5f87976cf41b1708f88b84589
   md5: 16cbd51eb7f0fc40a88c636006437c85
@@ -1642,90 +2200,6 @@ packages:
   - pkg:pypi/botocore-stubs?source=hash-mapping
   size: 46122
   timestamp: 1762994985884
-- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312h67db365_0.conda
-  sha256: 1acccd5464d81184ead80c017b4a7320c59c2774eb914f14d60ca8b4c55754e9
-  md5: 7c9245551ebbe6b6068aeda04060afaa
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - libbrotlicommon 1.2.0 h09219d5_0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/brotli?source=hash-mapping
-  size: 367744
-  timestamp: 1761592371750
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312hcae0c51_0.conda
-  sha256: 82bbb9a4430d639f0dc251d0a0a20dd661731dc6798481951dfa2e94ca3f191d
-  md5: 17e32d91d89e91631f97c217f192483b
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - libbrotlicommon 1.2.0 h87ba0bc_0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/brotli?source=hash-mapping
-  size: 359796
-  timestamp: 1761592677294
-- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312h9d5906e_0.conda
-  sha256: 48ffd069cab4b3b294daeb90e2536dafed5fe0a8476bc9fdcaa9924b691568f8
-  md5: 33b94eb79455950e69771bdd22db2988
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  constrains:
-  - libbrotlicommon 1.2.0 hc82b238_0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/brotli?source=hash-mapping
-  size: 335817
-  timestamp: 1761592773280
-- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
-  sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
-  md5: 51a19bba1b8ebfb60df25cde030b7ebc
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: bzip2-1.0.6
-  license_family: BSD
-  purls: []
-  size: 260341
-  timestamp: 1757437258798
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
-  sha256: b456200636bd5fecb2bec63f7e0985ad2097cf1b83d60ce0b6968dffa6d02aa1
-  md5: 58fd217444c2a5701a44244faf518206
-  depends:
-  - __osx >=11.0
-  license: bzip2-1.0.6
-  license_family: BSD
-  purls: []
-  size: 125061
-  timestamp: 1757437486465
-- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
-  sha256: d882712855624641f48aa9dc3f5feea2ed6b4e6004585d3616386a18186fe692
-  md5: 1077e9333c41ff0be8edd1a5ec0ddace
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: bzip2-1.0.6
-  license_family: BSD
-  purls: []
-  size: 55977
-  timestamp: 1757437738856
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-h4c7d964_0.conda
   sha256: 686a13bd2d4024fc99a22c1e0e68a7356af3ed3304a8d3ff6bb56249ad4e82f0
   md5: f98fb7db808b94bc1ec5b0e62f9f1069
@@ -1754,54 +2228,6 @@ packages:
   - pkg:pypi/certifi?source=compressed-mapping
   size: 157131
   timestamp: 1762976260320
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
-  sha256: 7dafe8173d5f94e46cf9cd597cc8ff476a8357fbbd4433a8b5697b2864845d9c
-  md5: 648ee28dcd4e07a1940a17da62eccd40
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - pycparser
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 295716
-  timestamp: 1761202958833
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
-  sha256: 597e986ac1a1bd1c9b29d6850e1cdea4a075ce8292af55568952ec670e7dd358
-  md5: 503ac138ad3cfc09459738c0f5750705
-  depends:
-  - __osx >=11.0
-  - libffi >=3.5.2,<3.6.0a0
-  - pycparser
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 288080
-  timestamp: 1761203317419
-- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
-  sha256: 3e3bdcb85a2e79fe47d9c8ce64903c76f663b39cb63b8e761f6f884e76127f82
-  md5: 46f7dccfee37a52a97c0ed6f33fcf0a3
-  depends:
-  - pycparser
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 291324
-  timestamp: 1761203195397
 - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
   sha256: d5696636733b3c301054b948cdd793f118efacce361d9bd4afb57d5980a9064f
   md5: 57df494053e17dce2ac3a0b33e1b2a2e
@@ -1860,132 +2286,6 @@ packages:
   - pkg:pypi/colorama?source=hash-mapping
   size: 27011
   timestamp: 1733218222191
-- pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
-  name: conda-forge-metadata
-  version: 0.12.0
-  sha256: ad727a92efbe41caf32412d0c4dcfd54da4f4a8b0ce8b55d5455a5f4631e542b
-  requires_dist:
-  - deprecated
-  - requests
-  - ruamel-yaml
-  - typing-extensions
-  - beautifulsoup4
-  - conda-oci-mirror
-  - conda-package-streaming>=0.12.0
-  - conda-oci-mirror ; extra == 'oci'
-- pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-  name: conda-oci-mirror
-  version: 0.1.0
-  requires_dist:
-  - click
-  - requests
-  - oras==0.1.14
-  - conda-package-handling
-  requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
-  name: conda-package-handling
-  version: 2.4.0
-  sha256: f835b17a5d8283555e13e0e7b7af80770007a1ff4924b07994aedad96bfb5e0c
-  requires_dist:
-  - conda-package-streaming>=0.9.0
-  - furo ; extra == 'docs'
-  - sphinx ; extra == 'docs'
-  - sphinx-argparse ; extra == 'docs'
-  - myst-parser ; extra == 'docs'
-  - mdit-py-plugins>=0.3.0 ; extra == 'docs'
-  - mock ; extra == 'test'
-  - pytest ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-mock ; extra == 'test'
-  - bottle ; extra == 'test'
-  requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
-  name: conda-package-streaming
-  version: 0.12.0
-  sha256: 45ae0ac0e198188703e845a42ac21292b73cd7077df358ea882d25923ab26f96
-  requires_dist:
-  - requests
-  - zstandard>=0.15
-  - furo ; extra == 'docs'
-  - sphinx ; extra == 'docs'
-  - myst-parser ; extra == 'docs'
-  - mdit-py-plugins>=0.3.0 ; extra == 'docs'
-  - pytest>=7 ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-mock ; extra == 'test'
-  - boto3 ; extra == 'test'
-  - boto3-stubs[essential] ; extra == 'test'
-  - bottle ; extra == 'test'
-  - conda ; extra == 'test'
-  - conda-package-handling>=2 ; extra == 'test'
-  - responses ; extra == 'test'
-  requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312hee9fe19_0.conda
-  sha256: 3b158c55cb494a5da669465ff86c774b2e65f0c8541a888aae970fb7a74aeb58
-  md5: 85ce285422e464eb1768aefd7d0d89f0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cffi >=1.14
-  - libgcc >=14
-  - openssl >=3.5.4,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
-  license_family: BSD
-  purls:
-  - pkg:pypi/cryptography?source=compressed-mapping
-  size: 1716207
-  timestamp: 1760605051655
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.3-py312h05a80bc_0.conda
-  sha256: 69917875e1e589fb2285fdbea2a1d494af32a0aa966221e3a1191fe3e93336e5
-  md5: c53c9d2886e552bcdcaf6f5c1abd86f7
-  depends:
-  - __osx >=11.0
-  - cffi >=1.14
-  - openssl >=3.5.4,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __osx >=11.0
-  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
-  license_family: BSD
-  purls:
-  - pkg:pypi/cryptography?source=hash-mapping
-  size: 1595177
-  timestamp: 1760605580913
-- conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-46.0.3-py312h84d000f_0.conda
-  sha256: 6a8cff1252e8ca4e3d4d6b50e0de9b383174c38272d45b3159b504946cd0f5e1
-  md5: 6c687d12bb89ff376129f524fafe00a8
-  depends:
-  - cffi >=1.14
-  - openssl >=3.5.4,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
-  license_family: BSD
-  purls:
-  - pkg:pypi/cryptography?source=hash-mapping
-  size: 1484025
-  timestamp: 1760605265071
-- pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
-  name: deprecated
-  version: 1.3.1
-  sha256: 597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f
-  requires_dist:
-  - wrapt>=1.10,<3
-  - inspect2 ; python_full_version < '3'
-  - tox ; extra == 'dev'
-  - pytest ; extra == 'dev'
-  - pytest-cov ; extra == 'dev'
-  - bump2version<1 ; extra == 'dev'
-  - setuptools ; python_full_version >= '3.12' and extra == 'dev'
-  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
 - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
   sha256: 6d977f0b2fc24fee21a9554389ab83070db341af6d6f09285360b2e09ef8b26e
   md5: 003b8ba0a94e2f1e117d0bd46aebc901
@@ -1997,32 +2297,6 @@ packages:
   - pkg:pypi/distlib?source=hash-mapping
   size: 275642
   timestamp: 1752823081585
-- conda: https://conda.anaconda.org/conda-forge/linux-64/docker-compose-5.0.0-h280c20c_0.conda
-  sha256: 69f3b15197189fd6ee23999f4bd4c9ff3e29a92a039ee3099616a64d7ad7ae53
-  md5: 942ae0eb872a6ea7b3bd2e08983852d1
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 9416022
-  timestamp: 1764757749451
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/docker-compose-5.0.0-h4bfb45e_0.conda
-  sha256: d60c260162f0a983185348f9b52f0158aa5158d3ca7d50af0a3ca2e8b52d6966
-  md5: a7aeac408069e1799622f334d5c2b184
-  depends:
-  - __osx >=12.3
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 8243486
-  timestamp: 1764757773864
-- conda: https://conda.anaconda.org/conda-forge/win-64/docker-compose-5.0.0-h6a83c73_0.conda
-  sha256: 32429c4bd4019616f6c490c383c595de10cb0d374817cd9b22592c73dd6279a5
-  md5: 210e963da2158edeb916fd120603e9ab
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 9205822
-  timestamp: 1764757778851
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
   sha256: ce61f4f99401a4bd455b89909153b40b9c823276aefcbb06f2044618696009ca
   md5: 72e42d28960d875c7654614f8b50939a
@@ -2044,51 +2318,6 @@ packages:
   - pkg:pypi/filelock?source=hash-mapping
   size: 17976
   timestamp: 1759948208140
-- conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-  sha256: f4e0e6cd241bc24afb2d6d08e5d2ba170fad2475e522bdf297b7271bba268be6
-  md5: 63e20cf7b7460019b423fc06abb96c60
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/frozenlist?source=hash-mapping
-  size: 55037
-  timestamp: 1752167383781
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
-  sha256: 690af95d69d97b6e1ffead1edd413ca0f8b9189fb867b6bd8fd351f8ad509043
-  md5: 9f016ae66f8ef7195561dbf7ce0e5944
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/frozenlist?source=hash-mapping
-  size: 52265
-  timestamp: 1752167495152
-- conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.7.0-py312hfdf67e6_0.conda
-  sha256: 804ebdfe1c49a31e275c8aaced937f96b794ad5ff228685349a13d450753d253
-  md5: 854caa541146c1c42d64c19fd63cbac9
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/frozenlist?source=hash-mapping
-  size: 49472
-  timestamp: 1752167442686
 - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
   md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -2125,28 +2354,6 @@ packages:
   - pkg:pypi/hyperframe?source=hash-mapping
   size: 17397
   timestamp: 1737618427549
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
-  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
-  md5: 8b189310083baabfb622af68fd9d3ae3
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 12129203
-  timestamp: 1720853576813
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
-  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
-  md5: 5eb22c1d7b3fc4abb50d92d621583137
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 11857802
-  timestamp: 1720853997952
 - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
   sha256: 32d5007d12e5731867908cbf5345f5cd44a6c8755a2e8e63e15a184826a51f82
   md5: 25f954b7dae6dd7b0dc004dab74f1ce9
@@ -2181,14 +2388,6 @@ packages:
   - pkg:pypi/iniconfig?source=compressed-mapping
   size: 13387
   timestamp: 1760831448842
-- pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
-  name: jinja2
-  version: 3.1.6
-  sha256: 85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-  requires_dist:
-  - markupsafe>=2.0
-  - babel>=2.7 ; extra == 'i18n'
-  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
   sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
   md5: 972bdca8f30147135f951847b30399ea
@@ -2200,355 +2399,6 @@ packages:
   - pkg:pypi/jmespath?source=hash-mapping
   size: 23708
   timestamp: 1733229244590
-- pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-  name: jsonschema
-  version: 4.25.1
-  sha256: 3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63
-  requires_dist:
-  - attrs>=22.2.0
-  - jsonschema-specifications>=2023.3.6
-  - referencing>=0.28.4
-  - rpds-py>=0.7.1
-  - fqdn ; extra == 'format'
-  - idna ; extra == 'format'
-  - isoduration ; extra == 'format'
-  - jsonpointer>1.13 ; extra == 'format'
-  - rfc3339-validator ; extra == 'format'
-  - rfc3987 ; extra == 'format'
-  - uri-template ; extra == 'format'
-  - webcolors>=1.11 ; extra == 'format'
-  - fqdn ; extra == 'format-nongpl'
-  - idna ; extra == 'format-nongpl'
-  - isoduration ; extra == 'format-nongpl'
-  - jsonpointer>1.13 ; extra == 'format-nongpl'
-  - rfc3339-validator ; extra == 'format-nongpl'
-  - rfc3986-validator>0.1.0 ; extra == 'format-nongpl'
-  - rfc3987-syntax>=1.1.0 ; extra == 'format-nongpl'
-  - uri-template ; extra == 'format-nongpl'
-  - webcolors>=24.6.0 ; extra == 'format-nongpl'
-  requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-  name: jsonschema-specifications
-  version: 2025.9.1
-  sha256: 98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe
-  requires_dist:
-  - referencing>=0.31.0
-  requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_5.conda
-  sha256: dab1fbf65abb05d3f2ee49dff90d60eeb2e02039fcb561343c7cea5dea523585
-  md5: 511ed8935448c1875776b60ad3daf3a1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - binutils_impl_linux-64 2.44
-  license: GPL-3.0-only
-  purls: []
-  size: 741516
-  timestamp: 1762674665675
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.5-hf598326_0.conda
-  sha256: cb441b85669eec99a593f59e6bb18c1d8a46d13eebadfc6a55f0b298109bf510
-  md5: fbfdbf6e554275d2661c4541f45fed53
-  depends:
-  - __osx >=11.0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  purls: []
-  size: 569449
-  timestamp: 1762258167196
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
-  sha256: da2080da8f0288b95dd86765c801c6e166c4619b910b11f9a8446fb852438dc2
-  md5: 4211416ecba1866fab0c6470986c22d6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - expat 2.7.1.*
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 74811
-  timestamp: 1752719572741
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
-  sha256: 8fbb17a56f51e7113ed511c5787e0dec0d4b10ef9df921c4fd1cccca0458f648
-  md5: b1ca5f21335782f71a8bd69bdc093f67
-  depends:
-  - __osx >=11.0
-  constrains:
-  - expat 2.7.1.*
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 65971
-  timestamp: 1752719657566
-- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
-  sha256: 8432ca842bdf8073ccecf016ccc9140c41c7114dc4ec77ca754551c01f780845
-  md5: 3608ffde260281fa641e70d6e34b1b96
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  constrains:
-  - expat 2.7.1.*
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 141322
-  timestamp: 1752719767870
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
-  sha256: 25cbdfa65580cfab1b8d15ee90b4c9f1e0d72128f1661449c9a999d341377d54
-  md5: 35f29eec58405aaf55e01cb470d8c26a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 57821
-  timestamp: 1760295480630
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
-  sha256: 9b8acdf42df61b7bfe8bdc545c016c29e61985e79748c64ad66df47dbc2e295f
-  md5: 411ff7cd5d1472bba0f55c0faf04453b
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 40251
-  timestamp: 1760295839166
-- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-  sha256: ddff25aaa4f0aa535413f5d831b04073789522890a4d8626366e43ecde1534a3
-  md5: ba4ad812d2afc22b9a34ce8327a0930f
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 44866
-  timestamp: 1760295760649
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
-  sha256: 08f9b87578ab981c7713e4e6a7d935e40766e10691732bba376d4964562bcb45
-  md5: c0374badb3a5d4b1372db28d19462c53
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgomp 15.2.0 h767d61c_7
-  - libgcc-ng ==15.2.0=*_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 822552
-  timestamp: 1759968052178
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
-  sha256: 2045066dd8e6e58aaf5ae2b722fb6dfdbb57c862b5f34ac7bfb58c40ef39b6ad
-  md5: 280ea6eee9e2ddefde25ff799c4f0363
-  depends:
-  - libgcc 15.2.0 h767d61c_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 29313
-  timestamp: 1759968065504
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
-  sha256: e9fb1c258c8e66ee278397b5822692527c5f5786d372fe7a869b900853f3f5ca
-  md5: f7b4d76975aac7e5d9e6ad13845f92fe
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 447919
-  timestamp: 1759967942498
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
-  sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
-  md5: 1a580f7796c7bf6393fddb8bbbde58dc
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD
-  purls: []
-  size: 112894
-  timestamp: 1749230047870
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
-  sha256: 0cb92a9e026e7bd4842f410a5c5c665c89b2eb97794ffddba519a626b8ce7285
-  md5: d6df911d4564d77c4374b02552cb17d1
-  depends:
-  - __osx >=11.0
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD
-  purls: []
-  size: 92286
-  timestamp: 1749230283517
-- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
-  sha256: 55764956eb9179b98de7cc0e55696f2eff8f7b83fc3ebff5e696ca358bca28cc
-  md5: c15148b2e18da456f5108ccb5e411446
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD
-  purls: []
-  size: 104935
-  timestamp: 1749230611612
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_2.conda
-  sha256: 329e66330a8f9cbb6a8d5995005478188eb4ba8a6b6391affa849744f4968492
-  md5: f61edadbb301530bd65a32646bd81552
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - liblzma 5.8.1 hb9d3cd8_2
-  license: 0BSD
-  purls: []
-  size: 439868
-  timestamp: 1749230061968
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
-  sha256: 974804430e24f0b00f3a48b67ec10c9f5441c9bb3d82cc0af51ba45b8a75a241
-  md5: 1201137f1a5ec9556032ffc04dcdde8d
-  depends:
-  - __osx >=11.0
-  - liblzma 5.8.1 h39f12f2_2
-  license: 0BSD
-  purls: []
-  size: 116244
-  timestamp: 1749230297170
-- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
-  sha256: 1ccff927a2d768403bad85e36ca3e931d96890adb4f503e1780c3412dd1e1298
-  md5: 42c90c4941c59f1b9f8fab627ad8ae76
-  depends:
-  - liblzma 5.8.1 h2466b09_2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: 0BSD
-  purls: []
-  size: 129344
-  timestamp: 1749230637001
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
-  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
-  md5: d864d34357c3b65a4b731f78c0801dc4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: LGPL-2.1-only
-  license_family: GPL
-  purls: []
-  size: 33731
-  timestamp: 1750274110928
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
-  sha256: 4c992dcd0e34b68f843e75406f7f303b1b97c248d18f3c7c330bdc0bc26ae0b3
-  md5: 729a572a3ebb8c43933b30edcc628ceb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=75.1,<76.0a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  license: blessing
-  purls: []
-  size: 945576
-  timestamp: 1762299687230
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.0-h8adb53f_0.conda
-  sha256: b43d198f147f46866e5336c4a6b91668beef698bfba69d1706158460eadb2c1b
-  md5: 5fb1945dbc6380e6fe7e939a62267772
-  depends:
-  - __osx >=11.0
-  - icu >=75.1,<76.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: blessing
-  purls: []
-  size: 909508
-  timestamp: 1762300078624
-- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
-  sha256: 2373bd7450693bd0f624966e1bee2f49b0bf0ffbc114275ed0a43cf35aec5b21
-  md5: d2c9300ebd2848862929b18c264d1b1e
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: blessing
-  purls: []
-  size: 1292710
-  timestamp: 1762299749044
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
-  sha256: 1b981647d9775e1cdeb2fab0a4dd9cd75a6b0de2963f6c3953dbd712f78334b3
-  md5: 5b767048b1b3ee9a954b06f4084f93dc
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc 15.2.0 h767d61c_7
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 3898269
-  timestamp: 1759968103436
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
-  sha256: 024fd46ac3ea8032a5ec3ea7b91c4c235701a8bf0e6520fe5e6539992a6bd05f
-  md5: f627678cf829bd70bccf141a19c3ad3e
-  depends:
-  - libstdcxx 15.2.0 h8f9b012_7
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 29343
-  timestamp: 1759968157195
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
-  sha256: e5ec6d2ad7eef538ddcb9ea62ad4346fde70a4736342c4ad87bd713641eb9808
-  md5: 80c07c68d2f6870250959dcc95b209d1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 37135
-  timestamp: 1758626800002
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
-  md5: edb0dca6bc32e4f4789199455a1dbeb8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 60963
-  timestamp: 1727963148474
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
-  md5: 369964e85dc26bfe78f41399b366c435
-  depends:
-  - __osx >=11.0
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 46438
-  timestamp: 1727963202283
-- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
-  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
-  md5: 41fbfac52c601159df6c01f875de31b9
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 55476
-  timestamp: 1727963768015
 - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
   sha256: 7b1da4b5c40385791dbc3cc85ceea9fad5da680a27d5d3cb8bfaa185e304a89e
   md5: 5b5203189eb668f042ac2b0826244964
@@ -2561,21 +2411,6 @@ packages:
   - pkg:pypi/markdown-it-py?source=hash-mapping
   size: 64736
   timestamp: 1754951288511
-- pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-  name: markupsafe
-  version: 3.0.3
-  sha256: d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d
-  requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
-  name: markupsafe
-  version: 3.0.3
-  sha256: 1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce
-  requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl
-  name: markupsafe
-  version: 3.0.3
-  sha256: 26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c
-  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
   sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
   md5: 592132998493b3ff25fd7479396e8351
@@ -2587,204 +2422,6 @@ packages:
   - pkg:pypi/mdurl?source=hash-mapping
   size: 14465
   timestamp: 1733255681319
-- pypi: https://files.pythonhosted.org/packages/83/d4/6991df072b34741a0c115e8d21dc2fe142e4b497319d762e957f6677f001/moto-5.1.18-py3-none-any.whl
-  name: moto
-  version: 5.1.18
-  sha256: b65aa8fc9032c5c574415451e14fd7da4e43fd50b8bdcb5f10289ad382c25bcf
-  requires_dist:
-  - boto3>=1.9.201
-  - botocore>=1.20.88,!=1.35.45,!=1.35.46
-  - cryptography>=35.0.0
-  - requests>=2.5
-  - xmltodict
-  - werkzeug>=0.5,!=2.2.0,!=2.2.1
-  - python-dateutil>=2.1,<3.0.0
-  - responses>=0.15.0,!=0.25.5
-  - jinja2>=2.10.1
-  - antlr4-python3-runtime ; extra == 'all'
-  - joserfc>=0.9.0 ; extra == 'all'
-  - jsonpath-ng ; extra == 'all'
-  - docker>=3.0.0 ; extra == 'all'
-  - graphql-core ; extra == 'all'
-  - pyyaml>=5.1 ; extra == 'all'
-  - cfn-lint>=0.40.0 ; extra == 'all'
-  - jsonschema ; extra == 'all'
-  - openapi-spec-validator>=0.5.0 ; extra == 'all'
-  - pyparsing>=3.0.7 ; extra == 'all'
-  - py-partiql-parser==0.6.3 ; extra == 'all'
-  - aws-xray-sdk>=0.93,!=0.96 ; extra == 'all'
-  - setuptools ; extra == 'all'
-  - multipart ; extra == 'all'
-  - antlr4-python3-runtime ; extra == 'proxy'
-  - joserfc>=0.9.0 ; extra == 'proxy'
-  - jsonpath-ng ; extra == 'proxy'
-  - docker>=2.5.1 ; extra == 'proxy'
-  - graphql-core ; extra == 'proxy'
-  - pyyaml>=5.1 ; extra == 'proxy'
-  - cfn-lint>=0.40.0 ; extra == 'proxy'
-  - openapi-spec-validator>=0.5.0 ; extra == 'proxy'
-  - pyparsing>=3.0.7 ; extra == 'proxy'
-  - py-partiql-parser==0.6.3 ; extra == 'proxy'
-  - aws-xray-sdk>=0.93,!=0.96 ; extra == 'proxy'
-  - setuptools ; extra == 'proxy'
-  - multipart ; extra == 'proxy'
-  - antlr4-python3-runtime ; extra == 'server'
-  - joserfc>=0.9.0 ; extra == 'server'
-  - jsonpath-ng ; extra == 'server'
-  - docker>=3.0.0 ; extra == 'server'
-  - graphql-core ; extra == 'server'
-  - pyyaml>=5.1 ; extra == 'server'
-  - cfn-lint>=0.40.0 ; extra == 'server'
-  - openapi-spec-validator>=0.5.0 ; extra == 'server'
-  - pyparsing>=3.0.7 ; extra == 'server'
-  - py-partiql-parser==0.6.3 ; extra == 'server'
-  - aws-xray-sdk>=0.93,!=0.96 ; extra == 'server'
-  - setuptools ; extra == 'server'
-  - flask!=2.2.0,!=2.2.1 ; extra == 'server'
-  - flask-cors ; extra == 'server'
-  - pyyaml>=5.1 ; extra == 'apigateway'
-  - joserfc>=0.9.0 ; extra == 'apigateway'
-  - openapi-spec-validator>=0.5.0 ; extra == 'apigateway'
-  - pyyaml>=5.1 ; extra == 'apigatewayv2'
-  - openapi-spec-validator>=0.5.0 ; extra == 'apigatewayv2'
-  - graphql-core ; extra == 'appsync'
-  - docker>=3.0.0 ; extra == 'awslambda'
-  - docker>=3.0.0 ; extra == 'batch'
-  - joserfc>=0.9.0 ; extra == 'cloudformation'
-  - docker>=3.0.0 ; extra == 'cloudformation'
-  - graphql-core ; extra == 'cloudformation'
-  - pyyaml>=5.1 ; extra == 'cloudformation'
-  - cfn-lint>=0.40.0 ; extra == 'cloudformation'
-  - openapi-spec-validator>=0.5.0 ; extra == 'cloudformation'
-  - pyparsing>=3.0.7 ; extra == 'cloudformation'
-  - py-partiql-parser==0.6.3 ; extra == 'cloudformation'
-  - aws-xray-sdk>=0.93,!=0.96 ; extra == 'cloudformation'
-  - setuptools ; extra == 'cloudformation'
-  - joserfc>=0.9.0 ; extra == 'cognitoidp'
-  - docker>=3.0.0 ; extra == 'dynamodb'
-  - py-partiql-parser==0.6.3 ; extra == 'dynamodb'
-  - docker>=3.0.0 ; extra == 'dynamodbstreams'
-  - py-partiql-parser==0.6.3 ; extra == 'dynamodbstreams'
-  - jsonpath-ng ; extra == 'events'
-  - pyparsing>=3.0.7 ; extra == 'glue'
-  - jsonschema ; extra == 'quicksight'
-  - joserfc>=0.9.0 ; extra == 'resourcegroupstaggingapi'
-  - docker>=3.0.0 ; extra == 'resourcegroupstaggingapi'
-  - graphql-core ; extra == 'resourcegroupstaggingapi'
-  - pyyaml>=5.1 ; extra == 'resourcegroupstaggingapi'
-  - cfn-lint>=0.40.0 ; extra == 'resourcegroupstaggingapi'
-  - openapi-spec-validator>=0.5.0 ; extra == 'resourcegroupstaggingapi'
-  - pyparsing>=3.0.7 ; extra == 'resourcegroupstaggingapi'
-  - py-partiql-parser==0.6.3 ; extra == 'resourcegroupstaggingapi'
-  - pyyaml>=5.1 ; extra == 's3'
-  - py-partiql-parser==0.6.3 ; extra == 's3'
-  - pyyaml>=5.1 ; extra == 's3crc32c'
-  - py-partiql-parser==0.6.3 ; extra == 's3crc32c'
-  - crc32c ; extra == 's3crc32c'
-  - pyyaml>=5.1 ; extra == 'ssm'
-  - antlr4-python3-runtime ; extra == 'stepfunctions'
-  - jsonpath-ng ; extra == 'stepfunctions'
-  - aws-xray-sdk>=0.93,!=0.96 ; extra == 'xray'
-  - setuptools ; extra == 'xray'
-  requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.3-py312h178313f_0.conda
-  sha256: c703d148a85ffb4f11001d31b7c4c686a46ad554eeeaa02c69da59fbf0e00dbb
-  md5: f4e246ec4ccdf73e50eefb0fa359a64e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/multidict?source=hash-mapping
-  size: 97272
-  timestamp: 1751310833783
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.6.3-py312hdb8e49c_0.conda
-  sha256: 4dda3bbaba0c35760950018aaae29f5ecae8d4d8964f6c61e50e8d29b293f674
-  md5: f6a2a3d93dec1aa42159639bb727c320
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/multidict?source=hash-mapping
-  size: 86934
-  timestamp: 1751311002651
-- conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.3-py312h05f76fc_0.conda
-  sha256: b36b420df7ea93fdf98aa12fe53e75a5af70a597561ccdafb5b9c2c492110cea
-  md5: 09a8b339af890c678ca0e56033482ca1
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/multidict?source=hash-mapping
-  size: 90694
-  timestamp: 1751310795306
-- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.18.2-py312h4c3975b_0.conda
-  sha256: fb90735bc355263cde3b3af4fff62dafa9d14b0aacb46f644c8ea7e82a9fd133
-  md5: 25163f59343531e356658848bde3fc7c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - mypy_extensions >=1.0.0
-  - pathspec >=0.9.0
-  - psutil >=4.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.6.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/mypy?source=hash-mapping
-  size: 19541793
-  timestamp: 1758278722332
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.18.2-py312h4409184_0.conda
-  sha256: fa98e62ee79e595291225cbfd2d0cb0bd01bf3cb7c41c9e50a00da640c5715b0
-  md5: c75fa7d854ed3c9ea67efc61a10f95c9
-  depends:
-  - __osx >=11.0
-  - mypy_extensions >=1.0.0
-  - pathspec >=0.9.0
-  - psutil >=4.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.6.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/mypy?source=hash-mapping
-  size: 10763924
-  timestamp: 1758279606662
-- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.18.2-py312he06e257_0.conda
-  sha256: 49fd4314ac16aa8f630d6cb81c0ea23443f8591714a7358bcb03daa57634d391
-  md5: a9aac184b94ad2ad1376ba47eb1d8c2a
-  depends:
-  - mypy_extensions >=1.0.0
-  - pathspec >=0.9.0
-  - psutil >=4.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.6.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/mypy?source=hash-mapping
-  size: 10319704
-  timestamp: 1758278688634
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06
@@ -2796,25 +2433,6 @@ packages:
   - pkg:pypi/mypy-extensions?source=hash-mapping
   size: 11766
   timestamp: 1745776666688
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-  sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
-  md5: 47e340acb35de30501a76c7c799c41d7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: X11 AND BSD-3-Clause
-  purls: []
-  size: 891641
-  timestamp: 1738195959188
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-  sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
-  md5: 068d497125e4bf8a66bf707254fff5ae
-  depends:
-  - __osx >=11.0
-  license: X11 AND BSD-3-Clause
-  purls: []
-  size: 797030
-  timestamp: 1738196177597
 - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
   sha256: 3636eec0e60466a00069b47ce94b6d88b01419b6577d8e393da44bb5bc8d3468
   md5: 7ba3f09fceae6a120d664217e58fe686
@@ -2827,65 +2445,6 @@ packages:
   - pkg:pypi/nodeenv?source=hash-mapping
   size: 34574
   timestamp: 1734112236147
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
-  sha256: a47271202f4518a484956968335b2521409c8173e123ab381e775c358c67fe6d
-  md5: 9ee58d5c534af06558933af3c845a780
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ca-certificates
-  - libgcc >=14
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 3165399
-  timestamp: 1762839186699
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
-  sha256: ebe93dafcc09e099782fe3907485d4e1671296bc14f8c383cb6f3dfebb773988
-  md5: b34dc4172653c13dcf453862f251af2b
-  depends:
-  - __osx >=11.0
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 3108371
-  timestamp: 1762839712322
-- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
-  sha256: 6d72d6f766293d4f2aa60c28c244c8efed6946c430814175f959ffe8cab899b3
-  md5: 84f8fb4afd1157f59098f618cd2437e4
-  depends:
-  - ca-certificates
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 9440812
-  timestamp: 1762841722179
-- pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
-  name: oras
-  version: 0.1.14
-  sha256: a3cf01cd279d507fb7fd2df7723a3fa1633955099fb3d412abe76cbe2ee10743
-  requires_dist:
-  - jsonschema
-  - requests
-  - jsonschema ; extra == 'all'
-  - requests ; extra == 'all'
-  - pytest>=4.6.2 ; extra == 'all'
-  - mypy ; extra == 'all'
-  - pyflakes ; extra == 'all'
-  - black ; extra == 'all'
-  - types-requests ; extra == 'all'
-  - isort ; extra == 'all'
-  - docker==5.0.1 ; extra == 'all'
-  - docker==5.0.1 ; extra == 'docker'
-  - pytest>=4.6.2 ; extra == 'tests'
-  - mypy ; extra == 'tests'
-  - pyflakes ; extra == 'tests'
-  - black ; extra == 'tests'
-  - types-requests ; extra == 'tests'
-  - isort ; extra == 'tests'
 - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
   sha256: 289861ed0c13a15d7bbb408796af4de72c2fe67e2bcb0de98f4c3fce259d7991
   md5: 58335b26c38bf4a20f399384c33cbcf9
@@ -2898,15 +2457,6 @@ packages:
   - pkg:pypi/packaging?source=hash-mapping
   size: 62477
   timestamp: 1745345660407
-- pypi: ./
-  name: parselmouth
-  version: 0.0.1
-  sha256: 5f3308a7a26fb97208a3cb8b0933f635c5ca0acca3f20f85befcb063d67e3b64
-  requires_dist:
-  - conda-forge-metadata>=0.12.0
-  - conda-oci-mirror @ git+https://github.com/channel-mirrors/conda-oci-mirror.git@25ea3e436f0b0bc5a9c646121efafc9c68e116cd
-  requires_python: ==3.12
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
   sha256: 9f64009cdf5b8e529995f18e03665b03f5d07c0b17445b8badef45bde76249ee
   md5: 617f15191456cc6a13db418a275435e5
@@ -2983,104 +2533,6 @@ packages:
   - pkg:pypi/pre-commit-hooks?source=hash-mapping
   size: 34686
   timestamp: 1712432480698
-- conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
-  sha256: d0ff67d89cf379a9f0367f563320621f0bc3969fe7f5c85e020f437de0927bb4
-  md5: 0cf580c1b73146bb9ff1bbdb4d4c8cf9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/propcache?source=hash-mapping
-  size: 54233
-  timestamp: 1744525107433
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py312h998013c_0.conda
-  sha256: dd97df075f5198d42cc4be6773f1c41a9c07d631d95f91bfee8e9953eccc965b
-  md5: d8280c97e09e85c72916a3d98a4076d7
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/propcache?source=hash-mapping
-  size: 51972
-  timestamp: 1744525285336
-- conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py312h31fea79_0.conda
-  sha256: 2824ee1e6597d81e6b2840ab9502031ee873cab57eadf8429788f1d3225e09ad
-  md5: 8a1fef8f5796cf8076c7d1897e28ed5a
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/propcache?source=hash-mapping
-  size: 50573
-  timestamp: 1744525241304
-- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.3-py312h5253ce2_0.conda
-  sha256: 1b679202ebccf47be64509a4fc2a438a66229403257630621651b2886b882597
-  md5: 82ce56c5a4a55165aed95e04923ab363
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/psutil?source=hash-mapping
-  size: 495011
-  timestamp: 1762092914381
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.1.3-py312h37e1c23_0.conda
-  sha256: cd831dfe655fdb581e1c2c71fa072d2fce38538474a36cbde3ae2dd910a2ae76
-  md5: d0b2f83de57eafaa6d7700b589c66096
-  depends:
-  - python
-  - __osx >=11.0
-  - python 3.12.* *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/psutil?source=hash-mapping
-  size: 508014
-  timestamp: 1762093047823
-- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.1.3-py312he5662c2_0.conda
-  sha256: 993629ec946988e047a4024f1f9c82cdf93e19e0a6f5d5fe908171d918fdbc8f
-  md5: f6d128e33550e9e8e3864a48c8f24230
-  depends:
-  - python
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/psutil?source=hash-mapping
-  size: 513061
-  timestamp: 1762092905129
-- pypi: https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl
-  name: py-partiql-parser
-  version: 0.6.3
-  sha256: deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582
-  requires_dist:
-  - black==22.6.0 ; extra == 'dev'
-  - flake8 ; extra == 'dev'
-  - mypy ; extra == 'dev'
-  - pytest ; extra == 'dev'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
   sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
   md5: 12c566707c80111f9799308d9e265aef
@@ -3109,56 +2561,6 @@ packages:
   - pkg:pypi/pydantic?source=hash-mapping
   size: 320446
   timestamp: 1762379584494
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
-  sha256: 07f899d035e06598682d3904d55f1529fac71b15e12b61d44d6a5fbf8521b0fe
-  md5: 56a776330a7d21db63a7c9d6c3711a04
-  depends:
-  - python
-  - typing-extensions >=4.6.0,!=4.7.0
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  purls:
-  - pkg:pypi/pydantic-core?source=compressed-mapping
-  size: 1935221
-  timestamp: 1762989004359
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
-  sha256: 048da0a49d644dba126905a1abcea0aee75efe88b5d621b9007b569dd753cfbc
-  md5: 88a76b4c912b6127d64298e3d8db980c
-  depends:
-  - python
-  - typing-extensions >=4.6.0,!=4.7.0
-  - python 3.12.* *_cpython
-  - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  purls:
-  - pkg:pypi/pydantic-core?source=hash-mapping
-  size: 1769018
-  timestamp: 1762989029329
-- conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.41.5-py312hdabe01f_1.conda
-  sha256: 06f5d122ac1c29679a6d588aa066c8684a087de12f84f3e81d90c205664eb62c
-  md5: 2e338a10e31828590cf031076bb143b6
-  depends:
-  - python
-  - typing-extensions >=4.6.0,!=4.7.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  purls:
-  - pkg:pypi/pydantic-core?source=hash-mapping
-  size: 1970249
-  timestamp: 1762989032818
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -3215,74 +2617,6 @@ packages:
   - pkg:pypi/pytest?source=hash-mapping
   size: 298822
   timestamp: 1762632428892
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
-  sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
-  md5: 7f97faab5bebcc2580f4f299285323da
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libnsl >=2.0.0,<2.1.0a0
-  - libsqlite >=3.43.0,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.3,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  purls: []
-  size: 32123473
-  timestamp: 1696324522323
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
-  sha256: eb66f8f249caa9d5a956c3a407f079e4779d652ebfc2a4b4f50dcea078e84fa8
-  md5: ed8ae98b1b510de68392971b9367d18c
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.0,<4.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.3,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  purls: []
-  size: 13306758
-  timestamp: 1696322682581
-- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
-  sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
-  md5: defd5d375853a2caff36a19d2d81a28e
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.0,<4.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - openssl >=3.1.3,<4.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  purls: []
-  size: 16140836
-  timestamp: 1696321871976
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8
@@ -3318,82 +2652,6 @@ packages:
   purls: []
   size: 6958
   timestamp: 1752805918820
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_0.conda
-  sha256: 1b3dc4c25c83093fff08b86a3574bc6b94ba355c8eba1f35d805c5e256455fc7
-  md5: fba10c2007c8b06f77c5a23ce3a635ad
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyyaml?source=hash-mapping
-  size: 204539
-  timestamp: 1758892248166
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h5748b74_0.conda
-  sha256: 690943c979a5bf014348933a68cd39e3bb9114d94371c4c5d846d2daaa82c7d9
-  md5: 6a2d7f8a026223c2fa1027c96c615752
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyyaml?source=hash-mapping
-  size: 190579
-  timestamp: 1758891996097
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py312h05f76fc_0.conda
-  sha256: 54d04e61d17edffeba1e5cad45f10f272a016b6feec1fa8fa6af364d84a7b4fc
-  md5: 4a68f80fbf85499f093101cc17ffbab7
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyyaml?source=hash-mapping
-  size: 180635
-  timestamp: 1758891847871
-- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
-  sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
-  md5: 283b96675859b20a825f8fa30f311446
-  depends:
-  - libgcc >=13
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 282480
-  timestamp: 1740379431762
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
-  sha256: 7db04684d3904f6151eff8673270922d31da1eea7fa73254d01c437f49702e34
-  md5: 63ef3f6e6d6d5c589e64f11263dc5676
-  depends:
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 252359
-  timestamp: 1740379663071
-- pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-  name: referencing
-  version: 0.37.0
-  sha256: 381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231
-  requires_dist:
-  - attrs>=22.2.0
-  - rpds-py>=0.7.0
-  - typing-extensions>=4.4.0 ; python_full_version < '3.13'
-  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
   sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
   md5: a30144e4156cdbb236f99ebb49828f8b
@@ -3411,26 +2669,6 @@ packages:
   - pkg:pypi/requests?source=hash-mapping
   size: 56690
   timestamp: 1684774408600
-- pypi: https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl
-  name: responses
-  version: 0.25.8
-  sha256: 0c710af92def29c8352ceadff0c3fe340ace27cf5af1bbe46fb71275bcd2831c
-  requires_dist:
-  - requests>=2.30.0,<3.0
-  - urllib3>=1.25.10,<3.0
-  - pyyaml
-  - pytest>=7.0.0 ; extra == 'tests'
-  - coverage>=6.0.0 ; extra == 'tests'
-  - pytest-cov ; extra == 'tests'
-  - pytest-asyncio ; extra == 'tests'
-  - pytest-httpserver ; extra == 'tests'
-  - flake8 ; extra == 'tests'
-  - types-pyyaml ; extra == 'tests'
-  - types-requests ; extra == 'tests'
-  - mypy ; extra == 'tests'
-  - tomli-w ; extra == 'tests'
-  - tomli ; python_full_version < '3.11' and extra == 'tests'
-  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
   sha256: 06a760c5ae572e72e865d5a87e9fe3cc171e1a9c996e63daf3db52ff1a0b4457
   md5: 7aed65d4ff222bfb7335997aa40b7da5
@@ -3445,217 +2683,6 @@ packages:
   - pkg:pypi/rich?source=hash-mapping
   size: 185646
   timestamp: 1733342347277
-- pypi: https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl
-  name: rpds-py
-  version: 0.30.0
-  sha256: a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl
-  name: rpds-py
-  version: 0.30.0
-  sha256: 6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: rpds-py
-  version: 0.30.0
-  sha256: 47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23
-  requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel-1.0-py312h7900ff3_11.conda
-  sha256: 338e94c880a467b6a276fbcf7cd770001d7b150e3cecae8237568c3e654d56e7
-  md5: d64200afbf154191e1414daf612b22e7
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 7409
-  timestamp: 1762507229125
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel-1.0-py312h81bd7bf_11.conda
-  sha256: f75f5ff2a2008755292b2a30e86fb864146405526120de5b5f35cd8f7413fbf5
-  md5: 4b6055493b3040225ac36dcd11971199
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 7498
-  timestamp: 1762507790344
-- conda: https://conda.anaconda.org/conda-forge/win-64/ruamel-1.0-py312h2e8e312_11.conda
-  sha256: 81df01d2d73fd52743acac17f4e527615be75ff21e70fe456597e62ea2f1252f
-  md5: 04a75b0a10bcc67ff1a0704119f36a3e
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 7759
-  timestamp: 1762507251707
-- pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
-  name: ruamel-yaml
-  version: 0.18.16
-  sha256: 048f26d64245bae57a4f9ef6feb5b552a386830ef7a826f235ffb804c59efbba
-  requires_dist:
-  - ruamel-yaml-clib>=0.2.7 ; python_full_version < '3.14' and platform_python_implementation == 'CPython'
-  - ruamel-yaml-jinja2>=0.2 ; extra == 'jinja2'
-  - ryd ; extra == 'docs'
-  - mercurial>5.7 ; extra == 'docs'
-  requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-  name: ruamel-yaml-clib
-  version: 0.2.15
-  sha256: 11e5499db1ccbc7f4b41f0565e4f799d863ea720e01d3e99fa0b7b5fcd7802c9
-  requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl
-  name: ruamel-yaml-clib
-  version: 0.2.15
-  sha256: 64da03cbe93c1e91af133f5bec37fd24d0d4ba2418eaf970d7166b0a26a148a2
-  requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl
-  name: ruamel-yaml-clib
-  version: 0.2.15
-  sha256: 2b216904750889133d9222b7b873c199d48ecbb12912aca78970f84a5aa1a4bc
-  requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.16-py312h4c3975b_0.conda
-  sha256: c792402cccee6a6dc01ad1451621e3ca002d72208ee28a33dc8594a19e3f7504
-  md5: 04c3560d6229bdfc73fc97586d8fe1a6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ruamel.yaml.clib >=0.1.2
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruamel-yaml?source=hash-mapping
-  size: 269849
-  timestamp: 1761160693733
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.16-py312h4409184_0.conda
-  sha256: a7d944ed52656ff0ae85199bb1fe152298ab9613daca4d83653fc12a3c9f2ebf
-  md5: 1672b251b3ef1ea8d1c36450d5a5cd54
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - ruamel.yaml.clib >=0.1.2
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruamel-yaml?source=hash-mapping
-  size: 270195
-  timestamp: 1761161065046
-- conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.16-py312he06e257_0.conda
-  sha256: b55993f6b64c1bdbf5793150efa215d7276fe40770554cca398c62e6a854b659
-  md5: 3ab6caf3d95accaa8deec1e854397dfb
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ruamel.yaml.clib >=0.1.2
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruamel-yaml?source=hash-mapping
-  size: 269605
-  timestamp: 1761160842605
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.14-py312h4c3975b_0.conda
-  sha256: 4c3c9311590f1ca072ac956aa2df712600a385ffc52e90982ebfc84da8db31c3
-  md5: b59f191f3cd25057889dbe91e1387231
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
-  size: 138966
-  timestamp: 1760564285617
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.14-py312h4409184_0.conda
-  sha256: 6e3b59e64c26f62562834752476b7308e72b9aada1a85ee98d3b57c4f7ab9139
-  md5: 701d9a8bcd57c5221df9b2384a6aef93
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
-  size: 116030
-  timestamp: 1760564523506
-- conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.14-py312he06e257_0.conda
-  sha256: 3d7362b2b16afb3a4e90de4a1af050933e262506e70177d4ba174b6427fc3b1a
-  md5: 02fb42bfd610f084377b05ec5bf25a18
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
-  size: 105494
-  timestamp: 1760564569285
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.5.7-py312hbe4c86d_0.conda
-  sha256: b8cc83042471c5740f29a5f3ce1ef7116b892095591907929671fe4e33345026
-  md5: 8871e1b8e5ec1c57d3769adc0b9e5d68
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruff?source=hash-mapping
-  size: 7184746
-  timestamp: 1723150552013
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.5.7-py312h3402d49_0.conda
-  sha256: 5a8808e0b4a4c60075ec7681fab7b0ce968e782ce6d30dae37362cea2c91ac90
-  md5: 674a57f24b46add25bca7cf9bd1a6d95
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruff?source=hash-mapping
-  size: 5889417
-  timestamp: 1723151024636
-- conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.5.7-py312h7a6832a_0.conda
-  sha256: 8ef95b535c160a81dad2c56f3755187e4fb7b01a444b9183ec11a1bbd46910e3
-  md5: 113ba113d1f49decf8d2fcd10f72090e
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruff?source=hash-mapping
-  size: 6314546
-  timestamp: 1723151403766
 - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.4-pyhd8ed1ab_1.conda
   sha256: 7903fe87708f151bd2a2782a8ed1714369feadcf4954ed724d1cce0798766399
   md5: ed873ecbcf00825b51ae5a272083ef2d
@@ -3701,46 +2728,6 @@ packages:
   - pkg:pypi/six?source=hash-mapping
   size: 18455
   timestamp: 1753199211006
-- pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
-  name: soupsieve
-  version: '2.8'
-  sha256: 0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c
-  requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
-  sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
-  md5: a0116df4f4ed05c303811a837d5b39d8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: TCL
-  license_family: BSD
-  purls: []
-  size: 3285204
-  timestamp: 1748387766691
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
-  sha256: cb86c522576fa95c6db4c878849af0bccfd3264daf0cc40dd18e7f4a7bfced0e
-  md5: 7362396c170252e7b7b0c8fb37fe9c78
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: TCL
-  license_family: BSD
-  purls: []
-  size: 3125538
-  timestamp: 1748388189063
-- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
-  sha256: e3614b0eb4abcc70d98eae159db59d9b4059ed743ef402081151a948dce95896
-  md5: ebd0e761de9aa879a51d22cc721bd095
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: TCL
-  license_family: BSD
-  purls: []
-  size: 3466348
-  timestamp: 1748388121356
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
   sha256: cb77c660b646c00a48ef942a9e1721ee46e90230c7c570cdeb5a893b5cce9bff
   md5: d2732eb636c264dc9aa4cbee404b1a53
@@ -3807,836 +2794,1421 @@ packages:
   purls: []
   size: 5471
   timestamp: 1747243737598
-- pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
-  name: types-aioboto3
-  version: 15.5.0
-  sha256: 8aed7c9b6fe9b59e6ce74f7a6db7b8a9912a34c8f80ed639fac1fa59d6b20aa1
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
+  sha256: 3da1da9f2f4321b5a0a003e358b60473315589d7ed3a9b9a1eda15c3d53d194e
+  md5: 99c349ad1a20d8a5be2fe155f91d8b3c
+  depends:
+  - pip
+  - python >=3.10,<4.0
+  license: MIT
+  purls:
+  - pkg:pypi/types-awscrt?source=hash-mapping
+  size: 22433
+  timestamp: 1762832622189
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-deprecated-1.2.15.20250304-pyhd8ed1ab_0.conda
+  sha256: d1ee3d82ab6043a7049f9f0599cec6b1347bd6a25c3d316225ba89b96d478be7
+  md5: 13d2a2b51f639360031a30fa011199fc
+  depends:
+  - python >=3.9
+  license: Apache-2.0 AND MIT
+  purls:
+  - pkg:pypi/types-deprecated?source=hash-mapping
+  size: 17824
+  timestamp: 1741080900085
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
+  sha256: ba565f80b5dc5d88f34587b391f21807efd54099516f11beae5cb29a7925fd3d
+  md5: 0fcb42ddc8e8ba6f906274108e6d891d
+  depends:
+  - python >=3.10
+  license: Apache-2.0 AND MIT
+  purls:
+  - pkg:pypi/types-pyyaml?source=compressed-mapping
+  size: 22060
+  timestamp: 1762942278334
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.20240406-pyhd8ed1ab_0.conda
+  sha256: de93470fe64b2baa5f8ef16a6edf849bb93542f301ed343d0ab4d6fd6116d742
+  md5: b4bc9b6dbc54191100b518a18be6045e
+  depends:
+  - python >=3.6
+  - urllib3 >=2
+  license: Apache-2.0 AND MIT
+  purls:
+  - pkg:pypi/types-requests?source=hash-mapping
+  size: 26072
+  timestamp: 1712378106245
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
+  sha256: c80bc9562af94f62c311eaa3eb0040c8660bed7301a7aa4f463d48ce404a8fdc
+  md5: 7ee7f6ac4c1d34c05b21210cabc61871
+  depends:
+  - python >=3.10
+  - types-awscrt
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/types-s3transfer?source=hash-mapping
+  size: 19446
+  timestamp: 1760383865409
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+  sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
+  md5: edd329d7d3a4ab45dcf905899a7a6115
+  depends:
+  - typing_extensions ==4.15.0 pyhcf101f3_0
+  license: PSF-2.0
+  license_family: PSF
+  purls: []
+  size: 91383
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
+  sha256: 8aaf69b828c2b94d0784f18f70f11aa032950d304e57e88467120b45c18c24fd
+  md5: 399701494e731ce73fdd86c185a3d1b4
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typing-inspection?source=compressed-mapping
+  size: 18799
+  timestamp: 1759301271883
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
+  md5: 0caa1af407ecff61170c9437a808404d
+  depends:
+  - python >=3.10
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/typing-extensions?source=hash-mapping
+  size: 51692
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+  sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
+  md5: 4222072737ccff51314b5ece9c7d6f5a
+  license: LicenseRef-Public-Domain
+  purls: []
+  size: 122968
+  timestamp: 1742727099393
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+  sha256: 4fb9789154bd666ca74e428d973df81087a697dbb987775bc3198d2215f240f8
+  md5: 436c165519e140cb08d246a4472a9d6a
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/urllib3?source=hash-mapping
+  size: 101735
+  timestamp: 1750271478254
+- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
+  sha256: 77193c99c6626c58446168d3700f9643d8c0dab1f6deb6b9dd039e6872781bfb
+  md5: cfccfd4e8d9de82ed75c8e2c91cab375
+  depends:
+  - distlib >=0.3.7,<1
+  - filelock >=3.12.2,<4
+  - platformdirs >=3.9.1,<5
+  - python >=3.10
+  - typing_extensions >=4.13.2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/virtualenv?source=hash-mapping
+  size: 4401341
+  timestamp: 1761726489722
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
+  md5: 75cb7132eb58d97896e173ef12ac9986
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/wheel?source=hash-mapping
+  size: 62931
+  timestamp: 1733130309598
+- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+  sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
+  md5: 46e441ba871f524e2b067929da3051c2
+  depends:
+  - __win
+  - python >=3.9
+  license: LicenseRef-Public-Domain
+  purls:
+  - pkg:pypi/win-inet-pton?source=hash-mapping
+  size: 9555
+  timestamp: 1733130678956
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.2-py312he52fbff_0.conda
+  sha256: 390d41a479791835dcb24631661d28892bd2b1c8dc5ad3c86612b44e02204508
+  md5: b4abb46248fa5cf1bc71c1b837c648a8
+  depends:
+  - __osx >=11.0
+  - aiohappyeyeballs >=2.5.0
+  - aiosignal >=1.4.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/aiohttp?source=hash-mapping
+  size: 985894
+  timestamp: 1761727100703
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py312hcae0c51_0.conda
+  sha256: 82bbb9a4430d639f0dc251d0a0a20dd661731dc6798481951dfa2e94ca3f191d
+  md5: 17e32d91d89e91631f97c217f192483b
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - libbrotlicommon 1.2.0 h87ba0bc_0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
+  size: 359796
+  timestamp: 1761592677294
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+  sha256: b456200636bd5fecb2bec63f7e0985ad2097cf1b83d60ce0b6968dffa6d02aa1
+  md5: 58fd217444c2a5701a44244faf518206
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 125061
+  timestamp: 1757437486465
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
+  sha256: 597e986ac1a1bd1c9b29d6850e1cdea4a075ce8292af55568952ec670e7dd358
+  md5: 503ac138ad3cfc09459738c0f5750705
+  depends:
+  - __osx >=11.0
+  - libffi >=3.5.2,<3.6.0a0
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  size: 288080
+  timestamp: 1761203317419
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.3-py312h05a80bc_0.conda
+  sha256: 69917875e1e589fb2285fdbea2a1d494af32a0aa966221e3a1191fe3e93336e5
+  md5: c53c9d2886e552bcdcaf6f5c1abd86f7
+  depends:
+  - __osx >=11.0
+  - cffi >=1.14
+  - openssl >=3.5.4,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  size: 1595177
+  timestamp: 1760605580913
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/docker-compose-5.0.0-h4bfb45e_0.conda
+  sha256: d60c260162f0a983185348f9b52f0158aa5158d3ca7d50af0a3ca2e8b52d6966
+  md5: a7aeac408069e1799622f334d5c2b184
+  depends:
+  - __osx >=12.3
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8243486
+  timestamp: 1764757773864
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
+  sha256: 690af95d69d97b6e1ffead1edd413ca0f8b9189fb867b6bd8fd351f8ad509043
+  md5: 9f016ae66f8ef7195561dbf7ce0e5944
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/frozenlist?source=hash-mapping
+  size: 52265
+  timestamp: 1752167495152
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
+  md5: 5eb22c1d7b3fc4abb50d92d621583137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 11857802
+  timestamp: 1720853997952
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.5-hf598326_0.conda
+  sha256: cb441b85669eec99a593f59e6bb18c1d8a46d13eebadfc6a55f0b298109bf510
+  md5: fbfdbf6e554275d2661c4541f45fed53
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 569449
+  timestamp: 1762258167196
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+  sha256: 8fbb17a56f51e7113ed511c5787e0dec0d4b10ef9df921c4fd1cccca0458f648
+  md5: b1ca5f21335782f71a8bd69bdc093f67
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 65971
+  timestamp: 1752719657566
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
+  sha256: 9b8acdf42df61b7bfe8bdc545c016c29e61985e79748c64ad66df47dbc2e295f
+  md5: 411ff7cd5d1472bba0f55c0faf04453b
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 40251
+  timestamp: 1760295839166
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+  sha256: 0cb92a9e026e7bd4842f410a5c5c665c89b2eb97794ffddba519a626b8ce7285
+  md5: d6df911d4564d77c4374b02552cb17d1
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  purls: []
+  size: 92286
+  timestamp: 1749230283517
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
+  sha256: 974804430e24f0b00f3a48b67ec10c9f5441c9bb3d82cc0af51ba45b8a75a241
+  md5: 1201137f1a5ec9556032ffc04dcdde8d
+  depends:
+  - __osx >=11.0
+  - liblzma 5.8.1 h39f12f2_2
+  license: 0BSD
+  purls: []
+  size: 116244
+  timestamp: 1749230297170
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.0-h8adb53f_0.conda
+  sha256: b43d198f147f46866e5336c4a6b91668beef698bfba69d1706158460eadb2c1b
+  md5: 5fb1945dbc6380e6fe7e939a62267772
+  depends:
+  - __osx >=11.0
+  - icu >=75.1,<76.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  purls: []
+  size: 909508
+  timestamp: 1762300078624
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.6.3-py312hdb8e49c_0.conda
+  sha256: 4dda3bbaba0c35760950018aaae29f5ecae8d4d8964f6c61e50e8d29b293f674
+  md5: f6a2a3d93dec1aa42159639bb727c320
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/multidict?source=hash-mapping
+  size: 86934
+  timestamp: 1751311002651
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.18.2-py312h4409184_0.conda
+  sha256: fa98e62ee79e595291225cbfd2d0cb0bd01bf3cb7c41c9e50a00da640c5715b0
+  md5: c75fa7d854ed3c9ea67efc61a10f95c9
+  depends:
+  - __osx >=11.0
+  - mypy_extensions >=1.0.0
+  - pathspec >=0.9.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.6.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mypy?source=hash-mapping
+  size: 10763924
+  timestamp: 1758279606662
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+  sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
+  md5: 068d497125e4bf8a66bf707254fff5ae
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 797030
+  timestamp: 1738196177597
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
+  sha256: ebe93dafcc09e099782fe3907485d4e1671296bc14f8c383cb6f3dfebb773988
+  md5: b34dc4172653c13dcf453862f251af2b
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3108371
+  timestamp: 1762839712322
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.3.1-py312h998013c_0.conda
+  sha256: dd97df075f5198d42cc4be6773f1c41a9c07d631d95f91bfee8e9953eccc965b
+  md5: d8280c97e09e85c72916a3d98a4076d7
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/propcache?source=hash-mapping
+  size: 51972
+  timestamp: 1744525285336
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.1.3-py312h37e1c23_0.conda
+  sha256: cd831dfe655fdb581e1c2c71fa072d2fce38538474a36cbde3ae2dd910a2ae76
+  md5: d0b2f83de57eafaa6d7700b589c66096
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.12.* *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
+  size: 508014
+  timestamp: 1762093047823
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
+  sha256: 048da0a49d644dba126905a1abcea0aee75efe88b5d621b9007b569dd753cfbc
+  md5: 88a76b4c912b6127d64298e3d8db980c
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - python 3.12.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1769018
+  timestamp: 1762989029329
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
+  sha256: eb66f8f249caa9d5a956c3a407f079e4779d652ebfc2a4b4f50dcea078e84fa8
+  md5: ed8ae98b1b510de68392971b9367d18c
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 13306758
+  timestamp: 1696322682581
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h5748b74_0.conda
+  sha256: 690943c979a5bf014348933a68cd39e3bb9114d94371c4c5d846d2daaa82c7d9
+  md5: 6a2d7f8a026223c2fa1027c96c615752
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 190579
+  timestamp: 1758891996097
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+  sha256: 7db04684d3904f6151eff8673270922d31da1eea7fa73254d01c437f49702e34
+  md5: 63ef3f6e6d6d5c589e64f11263dc5676
+  depends:
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 252359
+  timestamp: 1740379663071
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel-1.0-py312h81bd7bf_11.conda
+  sha256: f75f5ff2a2008755292b2a30e86fb864146405526120de5b5f35cd8f7413fbf5
+  md5: 4b6055493b3040225ac36dcd11971199
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 7498
+  timestamp: 1762507790344
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.16-py312h4409184_0.conda
+  sha256: a7d944ed52656ff0ae85199bb1fe152298ab9613daca4d83653fc12a3c9f2ebf
+  md5: 1672b251b3ef1ea8d1c36450d5a5cd54
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - ruamel.yaml.clib >=0.1.2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml?source=hash-mapping
+  size: 270195
+  timestamp: 1761161065046
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.14-py312h4409184_0.conda
+  sha256: 6e3b59e64c26f62562834752476b7308e72b9aada1a85ee98d3b57c4f7ab9139
+  md5: 701d9a8bcd57c5221df9b2384a6aef93
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
+  size: 116030
+  timestamp: 1760564523506
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.5.7-py312h3402d49_0.conda
+  sha256: 5a8808e0b4a4c60075ec7681fab7b0ce968e782ce6d30dae37362cea2c91ac90
+  md5: 674a57f24b46add25bca7cf9bd1a6d95
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruff?source=hash-mapping
+  size: 5889417
+  timestamp: 1723151024636
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+  sha256: cb86c522576fa95c6db4c878849af0bccfd3264daf0cc40dd18e7f4a7bfced0e
+  md5: 7362396c170252e7b7b0c8fb37fe9c78
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3125538
+  timestamp: 1748388189063
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.39.1-hd1458d2_0.conda
+  sha256: 44a86478536cc40ad4234a4732eb099811c5d83a961efa5ea5f75ae604cadd73
+  md5: f4aa5c348f4f0cc1b774cdaf9d5c1222
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 3004203
+  timestamp: 1762999586830
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312ha0dd364_6.conda
+  sha256: ba54fd3c178d30816fff864e5f6c7d05d4ec5f72a42ad15ec576a81fe28bea48
+  md5: 678a837ca1469257c13895124d4055b8
+  depends:
+  - __osx >=11.0
+  - cffi
+  - libcxx >=19
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
+  size: 14510
+  timestamp: 1761595134634
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py312h163523d_1.conda
+  sha256: b2be8bbfc1d7d63cd82f23c6aab0845b5dbbd835378b3c4e61b80b7d81ae9656
+  md5: 5658c0733acef1e0e2701aa1ebaa1f14
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/wrapt?source=hash-mapping
+  size: 61948
+  timestamp: 1756851912789
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_2.conda
+  sha256: afb747cf017b67cc31d54c6e6c4bd1b1e179fe487a3d23a856232ed7fd0b099b
+  md5: 39435c82e5a007ef64cbb153ecc40cfd
+  depends:
+  - __osx >=11.0
+  - liblzma 5.8.1 h39f12f2_2
+  - liblzma-devel 5.8.1 h39f12f2_2
+  - xz-gpl-tools 5.8.1 h9a6d368_2
+  - xz-tools 5.8.1 h39f12f2_2
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
+  size: 23995
+  timestamp: 1749230346887
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_2.conda
+  sha256: a0790cfb48d240e7b655b0d797a00040219cf39e3ee38e2104e548515df4f9c2
+  md5: 09b1442c1d49ac7c5f758c44695e77d1
+  depends:
+  - __osx >=11.0
+  - liblzma 5.8.1 h39f12f2_2
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
+  size: 34103
+  timestamp: 1749230329933
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.1-h39f12f2_2.conda
+  sha256: 9d1232705e3d175f600dc8e344af9182d0341cdaa73d25330591a28532951063
+  md5: 37996935aa33138fca43e4b4563b6a28
+  depends:
+  - __osx >=11.0
+  - liblzma 5.8.1 h39f12f2_2
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later
+  purls: []
+  size: 86425
+  timestamp: 1749230316106
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+  sha256: b03433b13d89f5567e828ea9f1a7d5c5d697bf374c28a4168d71e9464f5dafac
+  md5: 78a0fe9e9c50d2c381e8ee47e3ea437d
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 83386
+  timestamp: 1753484079473
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.22.0-py312h5748b74_0.conda
+  sha256: 49ee6fcb59e63cceb1f01777ac8b67d44633b6cdad5c47b02bc995f6e96955eb
+  md5: 0a28337559bbd97ff6d99598c7a3ffb4
+  depends:
+  - __osx >=11.0
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.1
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/yarl?source=hash-mapping
+  size: 144046
+  timestamp: 1761337516302
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py312h37e1c23_1.conda
+  sha256: af843b0fe62d128a70f91dc954b2cb692f349a237b461788bd25dd928d0d1ef8
+  md5: 9300889791d4decceea3728ad3b423ec
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - python 3.12.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  purls:
+  - pkg:pypi/zstandard?source=hash-mapping
+  size: 390920
+  timestamp: 1762512713481
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
+  sha256: 0d02046f57f7a1a3feae3e9d1aa2113788311f3cf37a3244c71e61a93177ba67
+  md5: e6f69c7bcccdefa417f056fa593b40f0
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 399979
+  timestamp: 1742433432699
+- conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.2-py312h927b8db_0.conda
+  sha256: 81391f625cac7dc7b336bfa4204d8b07371c593a72f1766886591434793f17aa
+  md5: 21bb8466e377d3d952a48a95dd52dbad
+  depends:
+  - aiohappyeyeballs >=2.5.0
+  - aiosignal >=1.4.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/aiohttp?source=hash-mapping
+  size: 960833
+  timestamp: 1761726896002
+- conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312h9d5906e_0.conda
+  sha256: 48ffd069cab4b3b294daeb90e2536dafed5fe0a8476bc9fdcaa9924b691568f8
+  md5: 33b94eb79455950e69771bdd22db2988
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libbrotlicommon 1.2.0 hc82b238_0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
+  size: 335817
+  timestamp: 1761592773280
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+  sha256: d882712855624641f48aa9dc3f5feea2ed6b4e6004585d3616386a18186fe692
+  md5: 1077e9333c41ff0be8edd1a5ec0ddace
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 55977
+  timestamp: 1757437738856
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
+  sha256: 3e3bdcb85a2e79fe47d9c8ce64903c76f663b39cb63b8e761f6f884e76127f82
+  md5: 46f7dccfee37a52a97c0ed6f33fcf0a3
+  depends:
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  size: 291324
+  timestamp: 1761203195397
+- conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-46.0.3-py312h84d000f_0.conda
+  sha256: 6a8cff1252e8ca4e3d4d6b50e0de9b383174c38272d45b3159b504946cd0f5e1
+  md5: 6c687d12bb89ff376129f524fafe00a8
+  depends:
+  - cffi >=1.14
+  - openssl >=3.5.4,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  size: 1484025
+  timestamp: 1760605265071
+- conda: https://conda.anaconda.org/conda-forge/win-64/docker-compose-5.0.0-h6a83c73_0.conda
+  sha256: 32429c4bd4019616f6c490c383c595de10cb0d374817cd9b22592c73dd6279a5
+  md5: 210e963da2158edeb916fd120603e9ab
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 9205822
+  timestamp: 1764757778851
+- conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.7.0-py312hfdf67e6_0.conda
+  sha256: 804ebdfe1c49a31e275c8aaced937f96b794ad5ff228685349a13d450753d253
+  md5: 854caa541146c1c42d64c19fd63cbac9
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/frozenlist?source=hash-mapping
+  size: 49472
+  timestamp: 1752167442686
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+  sha256: 8432ca842bdf8073ccecf016ccc9140c41c7114dc4ec77ca754551c01f780845
+  md5: 3608ffde260281fa641e70d6e34b1b96
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - expat 2.7.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 141322
+  timestamp: 1752719767870
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
+  sha256: ddff25aaa4f0aa535413f5d831b04073789522890a4d8626366e43ecde1534a3
+  md5: ba4ad812d2afc22b9a34ce8327a0930f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 44866
+  timestamp: 1760295760649
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+  sha256: 55764956eb9179b98de7cc0e55696f2eff8f7b83fc3ebff5e696ca358bca28cc
+  md5: c15148b2e18da456f5108ccb5e411446
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  purls: []
+  size: 104935
+  timestamp: 1749230611612
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
+  sha256: 1ccff927a2d768403bad85e36ca3e931d96890adb4f503e1780c3412dd1e1298
+  md5: 42c90c4941c59f1b9f8fab627ad8ae76
+  depends:
+  - liblzma 5.8.1 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: 0BSD
+  purls: []
+  size: 129344
+  timestamp: 1749230637001
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
+  sha256: 2373bd7450693bd0f624966e1bee2f49b0bf0ffbc114275ed0a43cf35aec5b21
+  md5: d2c9300ebd2848862929b18c264d1b1e
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  purls: []
+  size: 1292710
+  timestamp: 1762299749044
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 55476
+  timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.6.3-py312h05f76fc_0.conda
+  sha256: b36b420df7ea93fdf98aa12fe53e75a5af70a597561ccdafb5b9c2c492110cea
+  md5: 09a8b339af890c678ca0e56033482ca1
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/multidict?source=hash-mapping
+  size: 90694
+  timestamp: 1751310795306
+- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.18.2-py312he06e257_0.conda
+  sha256: 49fd4314ac16aa8f630d6cb81c0ea23443f8591714a7358bcb03daa57634d391
+  md5: a9aac184b94ad2ad1376ba47eb1d8c2a
+  depends:
+  - mypy_extensions >=1.0.0
+  - pathspec >=0.9.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.6.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mypy?source=hash-mapping
+  size: 10319704
+  timestamp: 1758278688634
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
+  sha256: 6d72d6f766293d4f2aa60c28c244c8efed6946c430814175f959ffe8cab899b3
+  md5: 84f8fb4afd1157f59098f618cd2437e4
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 9440812
+  timestamp: 1762841722179
+- conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py312h31fea79_0.conda
+  sha256: 2824ee1e6597d81e6b2840ab9502031ee873cab57eadf8429788f1d3225e09ad
+  md5: 8a1fef8f5796cf8076c7d1897e28ed5a
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/propcache?source=hash-mapping
+  size: 50573
+  timestamp: 1744525241304
+- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.1.3-py312he5662c2_0.conda
+  sha256: 993629ec946988e047a4024f1f9c82cdf93e19e0a6f5d5fe908171d918fdbc8f
+  md5: f6d128e33550e9e8e3864a48c8f24230
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
+  size: 513061
+  timestamp: 1762092905129
+- conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.41.5-py312hdabe01f_1.conda
+  sha256: 06f5d122ac1c29679a6d588aa066c8684a087de12f84f3e81d90c205664eb62c
+  md5: 2e338a10e31828590cf031076bb143b6
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1970249
+  timestamp: 1762989032818
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
+  sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
+  md5: defd5d375853a2caff36a19d2d81a28e
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 16140836
+  timestamp: 1696321871976
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py312h05f76fc_0.conda
+  sha256: 54d04e61d17edffeba1e5cad45f10f272a016b6feec1fa8fa6af364d84a7b4fc
+  md5: 4a68f80fbf85499f093101cc17ffbab7
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 180635
+  timestamp: 1758891847871
+- conda: https://conda.anaconda.org/conda-forge/win-64/ruamel-1.0-py312h2e8e312_11.conda
+  sha256: 81df01d2d73fd52743acac17f4e527615be75ff21e70fe456597e62ea2f1252f
+  md5: 04a75b0a10bcc67ff1a0704119f36a3e
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 7759
+  timestamp: 1762507251707
+- conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.16-py312he06e257_0.conda
+  sha256: b55993f6b64c1bdbf5793150efa215d7276fe40770554cca398c62e6a854b659
+  md5: 3ab6caf3d95accaa8deec1e854397dfb
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ruamel.yaml.clib >=0.1.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml?source=hash-mapping
+  size: 269605
+  timestamp: 1761160842605
+- conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.14-py312he06e257_0.conda
+  sha256: 3d7362b2b16afb3a4e90de4a1af050933e262506e70177d4ba174b6427fc3b1a
+  md5: 02fb42bfd610f084377b05ec5bf25a18
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
+  size: 105494
+  timestamp: 1760564569285
+- conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.5.7-py312h7a6832a_0.conda
+  sha256: 8ef95b535c160a81dad2c56f3755187e4fb7b01a444b9183ec11a1bbd46910e3
+  md5: 113ba113d1f49decf8d2fcd10f72090e
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruff?source=hash-mapping
+  size: 6314546
+  timestamp: 1723151403766
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+  sha256: e3614b0eb4abcc70d98eae159db59d9b4059ed743ef402081151a948dce95896
+  md5: ebd0e761de9aa879a51d22cc721bd095
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3466348
+  timestamp: 1748388121356
+- conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.39.1-h77a83cd_0.conda
+  sha256: 2b5b7f62abcb72c54a068402d6664d5410f9813a85f43cb926f47987ff217f00
+  md5: b3a39ae6a43115b311fe8c243851319f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2846362
+  timestamp: 1762999439525
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
+  md5: 71b24316859acd00bdb8b38f5e2ce328
+  constrains:
+  - vc14_runtime >=14.29.30037
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  purls: []
+  size: 694692
+  timestamp: 1756385147981
+- conda: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py312hf90b1b7_6.conda
+  sha256: 2b41d4e8243e31e8be51fa5cebc3f8017ecc7ed388af4e9498f97863459ec4e1
+  md5: 7369aaa9123f029c7aee5f34381f7742
+  depends:
+  - cffi
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
+  size: 18206
+  timestamp: 1761595067912
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
+  sha256: 82250af59af9ff3c6a635dd4c4764c631d854feb334d6747d356d949af44d7cf
+  md5: ef02bbe151253a72b8eda264a935db66
+  depends:
+  - vc14_runtime >=14.42.34433
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 18861
+  timestamp: 1760418772353
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
+  sha256: e3a3656b70d1202e0d042811ceb743bd0d9f7e00e2acdf824d231b044ef6c0fd
+  md5: 378d5dcec45eaea8d303da6f00447ac0
+  depends:
+  - ucrt >=10.0.20348.0
+  - vcomp14 14.44.35208 h818238b_32
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_32
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  purls: []
+  size: 682706
+  timestamp: 1760418629729
+- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
+  sha256: f3790c88fbbdc55874f41de81a4237b1b91eab75e05d0e58661518ff04d2a8a1
+  md5: 58f67b437acbf2764317ba273d731f1d
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_32
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  purls: []
+  size: 114846
+  timestamp: 1760418593847
+- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.3-py312he06e257_1.conda
+  sha256: f9e9e28ef3a0564a5588427b9503ed08e5fe3624b8f8132d60383439a47baafc
+  md5: fc10fd823d05bde83cda9e90dbef34ed
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/wrapt?source=hash-mapping
+  size: 63012
+  timestamp: 1756852490793
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.8.1-h208afaa_2.conda
+  sha256: 22289a81da4698bb8d13ac032a88a4a1f49505b2303885e1add3d8bd1a7b56e6
+  md5: fb3fa84ea37de9f12cc8ba730cec0bdc
+  depends:
+  - liblzma 5.8.1 h2466b09_2
+  - liblzma-devel 5.8.1 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz-tools 5.8.1 h2466b09_2
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
+  size: 24430
+  timestamp: 1749230691276
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.8.1-h2466b09_2.conda
+  sha256: 38712f0e62f61741ab69d7551fa863099f5be769bdf9fdbc28542134874b4e88
+  md5: e1b62ec0457e6ba10287a49854108fdb
+  depends:
+  - liblzma 5.8.1 h2466b09_2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later
+  purls: []
+  size: 67419
+  timestamp: 1749230666460
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
+  sha256: 80ee68c1e7683a35295232ea79bcc87279d31ffeda04a1665efdb43cbd50a309
+  md5: 433699cba6602098ae8957a323da2664
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 63944
+  timestamp: 1753484092156
+- conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.22.0-py312h05f76fc_0.conda
+  sha256: b622ef03b033a1c3984cb3e47e198370f23bf239c579a0c04f9179237fbb541b
+  md5: d4975947624e265fa594b86ce148a0c1
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - propcache >=0.2.1
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/yarl?source=hash-mapping
+  size: 141998
+  timestamp: 1761337573480
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py312he5662c2_1.conda
+  sha256: 49241574c373331ae63d9cb4978836db3b2571176a7db81fe48436c84ce38ff4
+  md5: e9e25949b682e95535068bae33153ba6
+  depends:
+  - python
+  - cffi >=1.11
+  - zstd >=1.5.7,<1.5.8.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - zstd >=1.5.7,<1.6.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  purls:
+  - pkg:pypi/zstandard?source=hash-mapping
+  size: 374949
+  timestamp: 1762512770373
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
+  sha256: bc64864377d809b904e877a98d0584f43836c9f2ef27d3d2a1421fa6eae7ca04
+  md5: 21f56217d6125fb30c3c3f10c786d751
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 354697
+  timestamp: 1742433568506
+- pypi: .
+  name: parselmouth
   requires_dist:
-  - botocore-stubs
-  - types-aiobotocore
-  - types-s3transfer
-  - typing-extensions>=4.1.0 ; python_full_version < '3.12'
-  - types-aiobotocore-full>=2.25.0,<2.26.0 ; extra == 'full'
-  - aioboto3==15.5.0 ; extra == 'aioboto3'
-  - types-aiobotocore-accessanalyzer>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-account>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-acm>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-acm-pca>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-aiops>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-amp>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-amplify>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-amplifybackend>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-amplifyuibuilder>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-apigateway>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-apigatewaymanagementapi>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-apigatewayv2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-appconfig>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-appconfigdata>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-appfabric>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-appflow>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-appintegrations>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-application-autoscaling>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-application-insights>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-application-signals>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-applicationcostprofiler>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-appmesh>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-apprunner>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-appstream>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-appsync>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-arc-region-switch>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-arc-zonal-shift>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-artifact>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-athena>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-auditmanager>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-autoscaling>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-autoscaling-plans>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-b2bi>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-backup>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-backup-gateway>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-backupsearch>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-batch>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bcm-dashboards>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bcm-data-exports>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bcm-pricing-calculator>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bcm-recommended-actions>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bedrock>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bedrock-agent>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bedrock-agent-runtime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bedrock-agentcore>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bedrock-agentcore-control>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bedrock-data-automation>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bedrock-data-automation-runtime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-bedrock-runtime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-billing>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-billingconductor>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-braket>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-budgets>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ce>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-chatbot>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-chime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-chime-sdk-identity>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-chime-sdk-media-pipelines>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-chime-sdk-meetings>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-chime-sdk-messaging>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-chime-sdk-voice>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cleanrooms>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cleanroomsml>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloud9>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudcontrol>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-clouddirectory>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudformation>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudfront>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudfront-keyvaluestore>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudhsm>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudhsmv2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudsearch>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudsearchdomain>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudtrail>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudtrail-data>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudwatch>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codeartifact>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codebuild>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codecatalyst>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codecommit>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codeconnections>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codedeploy>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codeguru-reviewer>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codeguru-security>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codeguruprofiler>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codepipeline>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codestar-connections>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-codestar-notifications>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cognito-identity>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cognito-idp>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cognito-sync>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-comprehend>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-comprehendmedical>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-compute-optimizer>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-config>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-connect>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-connect-contact-lens>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-connectcampaigns>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-connectcampaignsv2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-connectcases>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-connectparticipant>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-controlcatalog>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-controltower>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cost-optimization-hub>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cur>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-customer-profiles>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-databrew>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-dataexchange>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-datapipeline>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-datasync>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-datazone>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-dax>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-deadline>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-detective>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-devicefarm>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-devops-guru>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-directconnect>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-discovery>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-dlm>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-dms>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-docdb>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-docdb-elastic>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-drs>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ds>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ds-data>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-dsql>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-dynamodb>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-dynamodbstreams>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ebs>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ec2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ec2-instance-connect>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ecr>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ecr-public>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ecs>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-efs>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-eks>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-eks-auth>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-elasticache>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-elasticbeanstalk>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-elastictranscoder>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-elb>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-elbv2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-emr>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-emr-containers>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-emr-serverless>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-entityresolution>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-es>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-events>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-evidently>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-evs>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-finspace>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-finspace-data>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-firehose>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-fis>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-fms>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-forecast>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-forecastquery>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-frauddetector>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-freetier>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-fsx>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-gamelift>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-gameliftstreams>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-geo-maps>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-geo-places>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-geo-routes>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-glacier>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-globalaccelerator>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-glue>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-grafana>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-greengrass>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-greengrassv2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-groundstation>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-guardduty>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-health>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-healthlake>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iam>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-identitystore>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-imagebuilder>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-importexport>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-inspector>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-inspector-scan>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-inspector2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-internetmonitor>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-invoicing>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iot>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iot-data>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iot-jobs-data>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iot-managed-integrations>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iotanalytics>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iotdeviceadvisor>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iotevents>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iotevents-data>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iotfleetwise>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iotsecuretunneling>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iotsitewise>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iotthingsgraph>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iottwinmaker>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-iotwireless>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ivs>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ivs-realtime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ivschat>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kafka>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kafkaconnect>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kendra>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kendra-ranking>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-keyspaces>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-keyspacesstreams>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kinesis>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kinesis-video-archived-media>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kinesis-video-media>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kinesis-video-signaling>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kinesis-video-webrtc-storage>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kinesisanalytics>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kinesisanalyticsv2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kinesisvideo>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-kms>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-lakeformation>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-lambda>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-launch-wizard>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-lex-models>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-lex-runtime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-lexv2-models>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-lexv2-runtime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-license-manager>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-license-manager-linux-subscriptions>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-license-manager-user-subscriptions>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-lightsail>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-location>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-logs>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-lookoutequipment>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-m2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-machinelearning>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-macie2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mailmanager>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-managedblockchain>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-managedblockchain-query>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-marketplace-agreement>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-marketplace-catalog>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-marketplace-deployment>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-marketplace-entitlement>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-marketplace-reporting>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-marketplacecommerceanalytics>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mediaconnect>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mediaconvert>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-medialive>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mediapackage>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mediapackage-vod>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mediapackagev2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mediastore>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mediastore-data>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mediatailor>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-medical-imaging>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-memorydb>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-meteringmarketplace>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mgh>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mgn>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-migration-hub-refactor-spaces>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-migrationhub-config>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-migrationhuborchestrator>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-migrationhubstrategy>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mpa>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mq>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mturk>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-mwaa>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-neptune>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-neptune-graph>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-neptunedata>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-network-firewall>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-networkflowmonitor>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-networkmanager>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-networkmonitor>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-notifications>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-notificationscontacts>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-oam>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-observabilityadmin>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-odb>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-omics>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-opensearch>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-opensearchserverless>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-organizations>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-osis>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-outposts>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-panorama>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-partnercentral-selling>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-payment-cryptography>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-payment-cryptography-data>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-pca-connector-ad>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-pca-connector-scep>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-pcs>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-personalize>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-personalize-events>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-personalize-runtime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-pi>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-pinpoint>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-pinpoint-email>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-pinpoint-sms-voice>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-pinpoint-sms-voice-v2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-pipes>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-polly>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-pricing>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-proton>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-qapps>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-qbusiness>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-qconnect>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-quicksight>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ram>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-rbin>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-rds>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-rds-data>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-redshift>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-redshift-data>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-redshift-serverless>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-rekognition>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-repostspace>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-resiliencehub>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-resource-explorer-2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-resource-groups>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-resourcegroupstaggingapi>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-rolesanywhere>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-route53>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-route53-recovery-cluster>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-route53-recovery-control-config>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-route53-recovery-readiness>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-route53domains>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-route53profiles>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-route53resolver>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-rtbfabric>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-rum>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-s3>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-s3control>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-s3outposts>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-s3tables>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-s3vectors>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sagemaker>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sagemaker-a2i-runtime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sagemaker-edge>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sagemaker-featurestore-runtime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sagemaker-geospatial>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sagemaker-metrics>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sagemaker-runtime>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-savingsplans>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-scheduler>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-schemas>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sdb>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-secretsmanager>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-security-ir>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-securityhub>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-securitylake>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-serverlessrepo>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-service-quotas>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-servicecatalog>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-servicecatalog-appregistry>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-servicediscovery>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ses>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sesv2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-shield>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-signer>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-simspaceweaver>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-snow-device-management>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-snowball>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sns>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-socialmessaging>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sqs>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ssm>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ssm-contacts>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ssm-guiconnect>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ssm-incidents>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ssm-quicksetup>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-ssm-sap>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sso>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sso-admin>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sso-oidc>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-stepfunctions>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-storagegateway>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-sts>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-supplychain>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-support>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-support-app>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-swf>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-synthetics>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-taxsettings>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-textract>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-timestream-influxdb>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-timestream-query>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-timestream-write>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-tnb>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-transcribe>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-transfer>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-translate>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-trustedadvisor>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-verifiedpermissions>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-voice-id>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-vpc-lattice>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-waf>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-waf-regional>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-wafv2>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-wellarchitected>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-wisdom>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-workdocs>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-workmail>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-workmailmessageflow>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-workspaces>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-workspaces-instances>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-workspaces-thin-client>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-workspaces-web>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-xray>=2.25.0,<2.26.0 ; extra == 'all'
-  - types-aiobotocore-cloudformation>=2.25.0,<2.26.0 ; extra == 'essential'
-  - types-aiobotocore-dynamodb>=2.25.0,<2.26.0 ; extra == 'essential'
-  - types-aiobotocore-ec2>=2.25.0,<2.26.0 ; extra == 'essential'
-  - types-aiobotocore-lambda>=2.25.0,<2.26.0 ; extra == 'essential'
-  - types-aiobotocore-rds>=2.25.0,<2.26.0 ; extra == 'essential'
-  - types-aiobotocore-s3>=2.25.0,<2.26.0 ; extra == 'essential'
-  - types-aiobotocore-sqs>=2.25.0,<2.26.0 ; extra == 'essential'
-  - types-aiobotocore-accessanalyzer>=2.25.0,<2.26.0 ; extra == 'accessanalyzer'
-  - types-aiobotocore-account>=2.25.0,<2.26.0 ; extra == 'account'
-  - types-aiobotocore-acm>=2.25.0,<2.26.0 ; extra == 'acm'
-  - types-aiobotocore-acm-pca>=2.25.0,<2.26.0 ; extra == 'acm-pca'
-  - types-aiobotocore-aiops>=2.25.0,<2.26.0 ; extra == 'aiops'
-  - types-aiobotocore-amp>=2.25.0,<2.26.0 ; extra == 'amp'
-  - types-aiobotocore-amplify>=2.25.0,<2.26.0 ; extra == 'amplify'
-  - types-aiobotocore-amplifybackend>=2.25.0,<2.26.0 ; extra == 'amplifybackend'
-  - types-aiobotocore-amplifyuibuilder>=2.25.0,<2.26.0 ; extra == 'amplifyuibuilder'
-  - types-aiobotocore-apigateway>=2.25.0,<2.26.0 ; extra == 'apigateway'
-  - types-aiobotocore-apigatewaymanagementapi>=2.25.0,<2.26.0 ; extra == 'apigatewaymanagementapi'
-  - types-aiobotocore-apigatewayv2>=2.25.0,<2.26.0 ; extra == 'apigatewayv2'
-  - types-aiobotocore-appconfig>=2.25.0,<2.26.0 ; extra == 'appconfig'
-  - types-aiobotocore-appconfigdata>=2.25.0,<2.26.0 ; extra == 'appconfigdata'
-  - types-aiobotocore-appfabric>=2.25.0,<2.26.0 ; extra == 'appfabric'
-  - types-aiobotocore-appflow>=2.25.0,<2.26.0 ; extra == 'appflow'
-  - types-aiobotocore-appintegrations>=2.25.0,<2.26.0 ; extra == 'appintegrations'
-  - types-aiobotocore-application-autoscaling>=2.25.0,<2.26.0 ; extra == 'application-autoscaling'
-  - types-aiobotocore-application-insights>=2.25.0,<2.26.0 ; extra == 'application-insights'
-  - types-aiobotocore-application-signals>=2.25.0,<2.26.0 ; extra == 'application-signals'
-  - types-aiobotocore-applicationcostprofiler>=2.25.0,<2.26.0 ; extra == 'applicationcostprofiler'
-  - types-aiobotocore-appmesh>=2.25.0,<2.26.0 ; extra == 'appmesh'
-  - types-aiobotocore-apprunner>=2.25.0,<2.26.0 ; extra == 'apprunner'
-  - types-aiobotocore-appstream>=2.25.0,<2.26.0 ; extra == 'appstream'
-  - types-aiobotocore-appsync>=2.25.0,<2.26.0 ; extra == 'appsync'
-  - types-aiobotocore-arc-region-switch>=2.25.0,<2.26.0 ; extra == 'arc-region-switch'
-  - types-aiobotocore-arc-zonal-shift>=2.25.0,<2.26.0 ; extra == 'arc-zonal-shift'
-  - types-aiobotocore-artifact>=2.25.0,<2.26.0 ; extra == 'artifact'
-  - types-aiobotocore-athena>=2.25.0,<2.26.0 ; extra == 'athena'
-  - types-aiobotocore-auditmanager>=2.25.0,<2.26.0 ; extra == 'auditmanager'
-  - types-aiobotocore-autoscaling>=2.25.0,<2.26.0 ; extra == 'autoscaling'
-  - types-aiobotocore-autoscaling-plans>=2.25.0,<2.26.0 ; extra == 'autoscaling-plans'
-  - types-aiobotocore-b2bi>=2.25.0,<2.26.0 ; extra == 'b2bi'
-  - types-aiobotocore-backup>=2.25.0,<2.26.0 ; extra == 'backup'
-  - types-aiobotocore-backup-gateway>=2.25.0,<2.26.0 ; extra == 'backup-gateway'
-  - types-aiobotocore-backupsearch>=2.25.0,<2.26.0 ; extra == 'backupsearch'
-  - types-aiobotocore-batch>=2.25.0,<2.26.0 ; extra == 'batch'
-  - types-aiobotocore-bcm-dashboards>=2.25.0,<2.26.0 ; extra == 'bcm-dashboards'
-  - types-aiobotocore-bcm-data-exports>=2.25.0,<2.26.0 ; extra == 'bcm-data-exports'
-  - types-aiobotocore-bcm-pricing-calculator>=2.25.0,<2.26.0 ; extra == 'bcm-pricing-calculator'
-  - types-aiobotocore-bcm-recommended-actions>=2.25.0,<2.26.0 ; extra == 'bcm-recommended-actions'
-  - types-aiobotocore-bedrock>=2.25.0,<2.26.0 ; extra == 'bedrock'
-  - types-aiobotocore-bedrock-agent>=2.25.0,<2.26.0 ; extra == 'bedrock-agent'
-  - types-aiobotocore-bedrock-agent-runtime>=2.25.0,<2.26.0 ; extra == 'bedrock-agent-runtime'
-  - types-aiobotocore-bedrock-agentcore>=2.25.0,<2.26.0 ; extra == 'bedrock-agentcore'
-  - types-aiobotocore-bedrock-agentcore-control>=2.25.0,<2.26.0 ; extra == 'bedrock-agentcore-control'
-  - types-aiobotocore-bedrock-data-automation>=2.25.0,<2.26.0 ; extra == 'bedrock-data-automation'
-  - types-aiobotocore-bedrock-data-automation-runtime>=2.25.0,<2.26.0 ; extra == 'bedrock-data-automation-runtime'
-  - types-aiobotocore-bedrock-runtime>=2.25.0,<2.26.0 ; extra == 'bedrock-runtime'
-  - types-aiobotocore-billing>=2.25.0,<2.26.0 ; extra == 'billing'
-  - types-aiobotocore-billingconductor>=2.25.0,<2.26.0 ; extra == 'billingconductor'
-  - types-aiobotocore-braket>=2.25.0,<2.26.0 ; extra == 'braket'
-  - types-aiobotocore-budgets>=2.25.0,<2.26.0 ; extra == 'budgets'
-  - types-aiobotocore-ce>=2.25.0,<2.26.0 ; extra == 'ce'
-  - types-aiobotocore-chatbot>=2.25.0,<2.26.0 ; extra == 'chatbot'
-  - types-aiobotocore-chime>=2.25.0,<2.26.0 ; extra == 'chime'
-  - types-aiobotocore-chime-sdk-identity>=2.25.0,<2.26.0 ; extra == 'chime-sdk-identity'
-  - types-aiobotocore-chime-sdk-media-pipelines>=2.25.0,<2.26.0 ; extra == 'chime-sdk-media-pipelines'
-  - types-aiobotocore-chime-sdk-meetings>=2.25.0,<2.26.0 ; extra == 'chime-sdk-meetings'
-  - types-aiobotocore-chime-sdk-messaging>=2.25.0,<2.26.0 ; extra == 'chime-sdk-messaging'
-  - types-aiobotocore-chime-sdk-voice>=2.25.0,<2.26.0 ; extra == 'chime-sdk-voice'
-  - types-aiobotocore-cleanrooms>=2.25.0,<2.26.0 ; extra == 'cleanrooms'
-  - types-aiobotocore-cleanroomsml>=2.25.0,<2.26.0 ; extra == 'cleanroomsml'
-  - types-aiobotocore-cloud9>=2.25.0,<2.26.0 ; extra == 'cloud9'
-  - types-aiobotocore-cloudcontrol>=2.25.0,<2.26.0 ; extra == 'cloudcontrol'
-  - types-aiobotocore-clouddirectory>=2.25.0,<2.26.0 ; extra == 'clouddirectory'
-  - types-aiobotocore-cloudformation>=2.25.0,<2.26.0 ; extra == 'cloudformation'
-  - types-aiobotocore-cloudfront>=2.25.0,<2.26.0 ; extra == 'cloudfront'
-  - types-aiobotocore-cloudfront-keyvaluestore>=2.25.0,<2.26.0 ; extra == 'cloudfront-keyvaluestore'
-  - types-aiobotocore-cloudhsm>=2.25.0,<2.26.0 ; extra == 'cloudhsm'
-  - types-aiobotocore-cloudhsmv2>=2.25.0,<2.26.0 ; extra == 'cloudhsmv2'
-  - types-aiobotocore-cloudsearch>=2.25.0,<2.26.0 ; extra == 'cloudsearch'
-  - types-aiobotocore-cloudsearchdomain>=2.25.0,<2.26.0 ; extra == 'cloudsearchdomain'
-  - types-aiobotocore-cloudtrail>=2.25.0,<2.26.0 ; extra == 'cloudtrail'
-  - types-aiobotocore-cloudtrail-data>=2.25.0,<2.26.0 ; extra == 'cloudtrail-data'
-  - types-aiobotocore-cloudwatch>=2.25.0,<2.26.0 ; extra == 'cloudwatch'
-  - types-aiobotocore-codeartifact>=2.25.0,<2.26.0 ; extra == 'codeartifact'
-  - types-aiobotocore-codebuild>=2.25.0,<2.26.0 ; extra == 'codebuild'
-  - types-aiobotocore-codecatalyst>=2.25.0,<2.26.0 ; extra == 'codecatalyst'
-  - types-aiobotocore-codecommit>=2.25.0,<2.26.0 ; extra == 'codecommit'
-  - types-aiobotocore-codeconnections>=2.25.0,<2.26.0 ; extra == 'codeconnections'
-  - types-aiobotocore-codedeploy>=2.25.0,<2.26.0 ; extra == 'codedeploy'
-  - types-aiobotocore-codeguru-reviewer>=2.25.0,<2.26.0 ; extra == 'codeguru-reviewer'
-  - types-aiobotocore-codeguru-security>=2.25.0,<2.26.0 ; extra == 'codeguru-security'
-  - types-aiobotocore-codeguruprofiler>=2.25.0,<2.26.0 ; extra == 'codeguruprofiler'
-  - types-aiobotocore-codepipeline>=2.25.0,<2.26.0 ; extra == 'codepipeline'
-  - types-aiobotocore-codestar-connections>=2.25.0,<2.26.0 ; extra == 'codestar-connections'
-  - types-aiobotocore-codestar-notifications>=2.25.0,<2.26.0 ; extra == 'codestar-notifications'
-  - types-aiobotocore-cognito-identity>=2.25.0,<2.26.0 ; extra == 'cognito-identity'
-  - types-aiobotocore-cognito-idp>=2.25.0,<2.26.0 ; extra == 'cognito-idp'
-  - types-aiobotocore-cognito-sync>=2.25.0,<2.26.0 ; extra == 'cognito-sync'
-  - types-aiobotocore-comprehend>=2.25.0,<2.26.0 ; extra == 'comprehend'
-  - types-aiobotocore-comprehendmedical>=2.25.0,<2.26.0 ; extra == 'comprehendmedical'
-  - types-aiobotocore-compute-optimizer>=2.25.0,<2.26.0 ; extra == 'compute-optimizer'
-  - types-aiobotocore-config>=2.25.0,<2.26.0 ; extra == 'config'
-  - types-aiobotocore-connect>=2.25.0,<2.26.0 ; extra == 'connect'
-  - types-aiobotocore-connect-contact-lens>=2.25.0,<2.26.0 ; extra == 'connect-contact-lens'
-  - types-aiobotocore-connectcampaigns>=2.25.0,<2.26.0 ; extra == 'connectcampaigns'
-  - types-aiobotocore-connectcampaignsv2>=2.25.0,<2.26.0 ; extra == 'connectcampaignsv2'
-  - types-aiobotocore-connectcases>=2.25.0,<2.26.0 ; extra == 'connectcases'
-  - types-aiobotocore-connectparticipant>=2.25.0,<2.26.0 ; extra == 'connectparticipant'
-  - types-aiobotocore-controlcatalog>=2.25.0,<2.26.0 ; extra == 'controlcatalog'
-  - types-aiobotocore-controltower>=2.25.0,<2.26.0 ; extra == 'controltower'
-  - types-aiobotocore-cost-optimization-hub>=2.25.0,<2.26.0 ; extra == 'cost-optimization-hub'
-  - types-aiobotocore-cur>=2.25.0,<2.26.0 ; extra == 'cur'
-  - types-aiobotocore-customer-profiles>=2.25.0,<2.26.0 ; extra == 'customer-profiles'
-  - types-aiobotocore-databrew>=2.25.0,<2.26.0 ; extra == 'databrew'
-  - types-aiobotocore-dataexchange>=2.25.0,<2.26.0 ; extra == 'dataexchange'
-  - types-aiobotocore-datapipeline>=2.25.0,<2.26.0 ; extra == 'datapipeline'
-  - types-aiobotocore-datasync>=2.25.0,<2.26.0 ; extra == 'datasync'
-  - types-aiobotocore-datazone>=2.25.0,<2.26.0 ; extra == 'datazone'
-  - types-aiobotocore-dax>=2.25.0,<2.26.0 ; extra == 'dax'
-  - types-aiobotocore-deadline>=2.25.0,<2.26.0 ; extra == 'deadline'
-  - types-aiobotocore-detective>=2.25.0,<2.26.0 ; extra == 'detective'
-  - types-aiobotocore-devicefarm>=2.25.0,<2.26.0 ; extra == 'devicefarm'
-  - types-aiobotocore-devops-guru>=2.25.0,<2.26.0 ; extra == 'devops-guru'
-  - types-aiobotocore-directconnect>=2.25.0,<2.26.0 ; extra == 'directconnect'
-  - types-aiobotocore-discovery>=2.25.0,<2.26.0 ; extra == 'discovery'
-  - types-aiobotocore-dlm>=2.25.0,<2.26.0 ; extra == 'dlm'
-  - types-aiobotocore-dms>=2.25.0,<2.26.0 ; extra == 'dms'
-  - types-aiobotocore-docdb>=2.25.0,<2.26.0 ; extra == 'docdb'
-  - types-aiobotocore-docdb-elastic>=2.25.0,<2.26.0 ; extra == 'docdb-elastic'
-  - types-aiobotocore-drs>=2.25.0,<2.26.0 ; extra == 'drs'
-  - types-aiobotocore-ds>=2.25.0,<2.26.0 ; extra == 'ds'
-  - types-aiobotocore-ds-data>=2.25.0,<2.26.0 ; extra == 'ds-data'
-  - types-aiobotocore-dsql>=2.25.0,<2.26.0 ; extra == 'dsql'
-  - types-aiobotocore-dynamodb>=2.25.0,<2.26.0 ; extra == 'dynamodb'
-  - types-aiobotocore-dynamodbstreams>=2.25.0,<2.26.0 ; extra == 'dynamodbstreams'
-  - types-aiobotocore-ebs>=2.25.0,<2.26.0 ; extra == 'ebs'
-  - types-aiobotocore-ec2>=2.25.0,<2.26.0 ; extra == 'ec2'
-  - types-aiobotocore-ec2-instance-connect>=2.25.0,<2.26.0 ; extra == 'ec2-instance-connect'
-  - types-aiobotocore-ecr>=2.25.0,<2.26.0 ; extra == 'ecr'
-  - types-aiobotocore-ecr-public>=2.25.0,<2.26.0 ; extra == 'ecr-public'
-  - types-aiobotocore-ecs>=2.25.0,<2.26.0 ; extra == 'ecs'
-  - types-aiobotocore-efs>=2.25.0,<2.26.0 ; extra == 'efs'
-  - types-aiobotocore-eks>=2.25.0,<2.26.0 ; extra == 'eks'
-  - types-aiobotocore-eks-auth>=2.25.0,<2.26.0 ; extra == 'eks-auth'
-  - types-aiobotocore-elasticache>=2.25.0,<2.26.0 ; extra == 'elasticache'
-  - types-aiobotocore-elasticbeanstalk>=2.25.0,<2.26.0 ; extra == 'elasticbeanstalk'
-  - types-aiobotocore-elastictranscoder>=2.25.0,<2.26.0 ; extra == 'elastictranscoder'
-  - types-aiobotocore-elb>=2.25.0,<2.26.0 ; extra == 'elb'
-  - types-aiobotocore-elbv2>=2.25.0,<2.26.0 ; extra == 'elbv2'
-  - types-aiobotocore-emr>=2.25.0,<2.26.0 ; extra == 'emr'
-  - types-aiobotocore-emr-containers>=2.25.0,<2.26.0 ; extra == 'emr-containers'
-  - types-aiobotocore-emr-serverless>=2.25.0,<2.26.0 ; extra == 'emr-serverless'
-  - types-aiobotocore-entityresolution>=2.25.0,<2.26.0 ; extra == 'entityresolution'
-  - types-aiobotocore-es>=2.25.0,<2.26.0 ; extra == 'es'
-  - types-aiobotocore-events>=2.25.0,<2.26.0 ; extra == 'events'
-  - types-aiobotocore-evidently>=2.25.0,<2.26.0 ; extra == 'evidently'
-  - types-aiobotocore-evs>=2.25.0,<2.26.0 ; extra == 'evs'
-  - types-aiobotocore-finspace>=2.25.0,<2.26.0 ; extra == 'finspace'
-  - types-aiobotocore-finspace-data>=2.25.0,<2.26.0 ; extra == 'finspace-data'
-  - types-aiobotocore-firehose>=2.25.0,<2.26.0 ; extra == 'firehose'
-  - types-aiobotocore-fis>=2.25.0,<2.26.0 ; extra == 'fis'
-  - types-aiobotocore-fms>=2.25.0,<2.26.0 ; extra == 'fms'
-  - types-aiobotocore-forecast>=2.25.0,<2.26.0 ; extra == 'forecast'
-  - types-aiobotocore-forecastquery>=2.25.0,<2.26.0 ; extra == 'forecastquery'
-  - types-aiobotocore-frauddetector>=2.25.0,<2.26.0 ; extra == 'frauddetector'
-  - types-aiobotocore-freetier>=2.25.0,<2.26.0 ; extra == 'freetier'
-  - types-aiobotocore-fsx>=2.25.0,<2.26.0 ; extra == 'fsx'
-  - types-aiobotocore-gamelift>=2.25.0,<2.26.0 ; extra == 'gamelift'
-  - types-aiobotocore-gameliftstreams>=2.25.0,<2.26.0 ; extra == 'gameliftstreams'
-  - types-aiobotocore-geo-maps>=2.25.0,<2.26.0 ; extra == 'geo-maps'
-  - types-aiobotocore-geo-places>=2.25.0,<2.26.0 ; extra == 'geo-places'
-  - types-aiobotocore-geo-routes>=2.25.0,<2.26.0 ; extra == 'geo-routes'
-  - types-aiobotocore-glacier>=2.25.0,<2.26.0 ; extra == 'glacier'
-  - types-aiobotocore-globalaccelerator>=2.25.0,<2.26.0 ; extra == 'globalaccelerator'
-  - types-aiobotocore-glue>=2.25.0,<2.26.0 ; extra == 'glue'
-  - types-aiobotocore-grafana>=2.25.0,<2.26.0 ; extra == 'grafana'
-  - types-aiobotocore-greengrass>=2.25.0,<2.26.0 ; extra == 'greengrass'
-  - types-aiobotocore-greengrassv2>=2.25.0,<2.26.0 ; extra == 'greengrassv2'
-  - types-aiobotocore-groundstation>=2.25.0,<2.26.0 ; extra == 'groundstation'
-  - types-aiobotocore-guardduty>=2.25.0,<2.26.0 ; extra == 'guardduty'
-  - types-aiobotocore-health>=2.25.0,<2.26.0 ; extra == 'health'
-  - types-aiobotocore-healthlake>=2.25.0,<2.26.0 ; extra == 'healthlake'
-  - types-aiobotocore-iam>=2.25.0,<2.26.0 ; extra == 'iam'
-  - types-aiobotocore-identitystore>=2.25.0,<2.26.0 ; extra == 'identitystore'
-  - types-aiobotocore-imagebuilder>=2.25.0,<2.26.0 ; extra == 'imagebuilder'
-  - types-aiobotocore-importexport>=2.25.0,<2.26.0 ; extra == 'importexport'
-  - types-aiobotocore-inspector>=2.25.0,<2.26.0 ; extra == 'inspector'
-  - types-aiobotocore-inspector-scan>=2.25.0,<2.26.0 ; extra == 'inspector-scan'
-  - types-aiobotocore-inspector2>=2.25.0,<2.26.0 ; extra == 'inspector2'
-  - types-aiobotocore-internetmonitor>=2.25.0,<2.26.0 ; extra == 'internetmonitor'
-  - types-aiobotocore-invoicing>=2.25.0,<2.26.0 ; extra == 'invoicing'
-  - types-aiobotocore-iot>=2.25.0,<2.26.0 ; extra == 'iot'
-  - types-aiobotocore-iot-data>=2.25.0,<2.26.0 ; extra == 'iot-data'
-  - types-aiobotocore-iot-jobs-data>=2.25.0,<2.26.0 ; extra == 'iot-jobs-data'
-  - types-aiobotocore-iot-managed-integrations>=2.25.0,<2.26.0 ; extra == 'iot-managed-integrations'
-  - types-aiobotocore-iotanalytics>=2.25.0,<2.26.0 ; extra == 'iotanalytics'
-  - types-aiobotocore-iotdeviceadvisor>=2.25.0,<2.26.0 ; extra == 'iotdeviceadvisor'
-  - types-aiobotocore-iotevents>=2.25.0,<2.26.0 ; extra == 'iotevents'
-  - types-aiobotocore-iotevents-data>=2.25.0,<2.26.0 ; extra == 'iotevents-data'
-  - types-aiobotocore-iotfleetwise>=2.25.0,<2.26.0 ; extra == 'iotfleetwise'
-  - types-aiobotocore-iotsecuretunneling>=2.25.0,<2.26.0 ; extra == 'iotsecuretunneling'
-  - types-aiobotocore-iotsitewise>=2.25.0,<2.26.0 ; extra == 'iotsitewise'
-  - types-aiobotocore-iotthingsgraph>=2.25.0,<2.26.0 ; extra == 'iotthingsgraph'
-  - types-aiobotocore-iottwinmaker>=2.25.0,<2.26.0 ; extra == 'iottwinmaker'
-  - types-aiobotocore-iotwireless>=2.25.0,<2.26.0 ; extra == 'iotwireless'
-  - types-aiobotocore-ivs>=2.25.0,<2.26.0 ; extra == 'ivs'
-  - types-aiobotocore-ivs-realtime>=2.25.0,<2.26.0 ; extra == 'ivs-realtime'
-  - types-aiobotocore-ivschat>=2.25.0,<2.26.0 ; extra == 'ivschat'
-  - types-aiobotocore-kafka>=2.25.0,<2.26.0 ; extra == 'kafka'
-  - types-aiobotocore-kafkaconnect>=2.25.0,<2.26.0 ; extra == 'kafkaconnect'
-  - types-aiobotocore-kendra>=2.25.0,<2.26.0 ; extra == 'kendra'
-  - types-aiobotocore-kendra-ranking>=2.25.0,<2.26.0 ; extra == 'kendra-ranking'
-  - types-aiobotocore-keyspaces>=2.25.0,<2.26.0 ; extra == 'keyspaces'
-  - types-aiobotocore-keyspacesstreams>=2.25.0,<2.26.0 ; extra == 'keyspacesstreams'
-  - types-aiobotocore-kinesis>=2.25.0,<2.26.0 ; extra == 'kinesis'
-  - types-aiobotocore-kinesis-video-archived-media>=2.25.0,<2.26.0 ; extra == 'kinesis-video-archived-media'
-  - types-aiobotocore-kinesis-video-media>=2.25.0,<2.26.0 ; extra == 'kinesis-video-media'
-  - types-aiobotocore-kinesis-video-signaling>=2.25.0,<2.26.0 ; extra == 'kinesis-video-signaling'
-  - types-aiobotocore-kinesis-video-webrtc-storage>=2.25.0,<2.26.0 ; extra == 'kinesis-video-webrtc-storage'
-  - types-aiobotocore-kinesisanalytics>=2.25.0,<2.26.0 ; extra == 'kinesisanalytics'
-  - types-aiobotocore-kinesisanalyticsv2>=2.25.0,<2.26.0 ; extra == 'kinesisanalyticsv2'
-  - types-aiobotocore-kinesisvideo>=2.25.0,<2.26.0 ; extra == 'kinesisvideo'
-  - types-aiobotocore-kms>=2.25.0,<2.26.0 ; extra == 'kms'
-  - types-aiobotocore-lakeformation>=2.25.0,<2.26.0 ; extra == 'lakeformation'
-  - types-aiobotocore-lambda>=2.25.0,<2.26.0 ; extra == 'lambda'
-  - types-aiobotocore-launch-wizard>=2.25.0,<2.26.0 ; extra == 'launch-wizard'
-  - types-aiobotocore-lex-models>=2.25.0,<2.26.0 ; extra == 'lex-models'
-  - types-aiobotocore-lex-runtime>=2.25.0,<2.26.0 ; extra == 'lex-runtime'
-  - types-aiobotocore-lexv2-models>=2.25.0,<2.26.0 ; extra == 'lexv2-models'
-  - types-aiobotocore-lexv2-runtime>=2.25.0,<2.26.0 ; extra == 'lexv2-runtime'
-  - types-aiobotocore-license-manager>=2.25.0,<2.26.0 ; extra == 'license-manager'
-  - types-aiobotocore-license-manager-linux-subscriptions>=2.25.0,<2.26.0 ; extra == 'license-manager-linux-subscriptions'
-  - types-aiobotocore-license-manager-user-subscriptions>=2.25.0,<2.26.0 ; extra == 'license-manager-user-subscriptions'
-  - types-aiobotocore-lightsail>=2.25.0,<2.26.0 ; extra == 'lightsail'
-  - types-aiobotocore-location>=2.25.0,<2.26.0 ; extra == 'location'
-  - types-aiobotocore-logs>=2.25.0,<2.26.0 ; extra == 'logs'
-  - types-aiobotocore-lookoutequipment>=2.25.0,<2.26.0 ; extra == 'lookoutequipment'
-  - types-aiobotocore-m2>=2.25.0,<2.26.0 ; extra == 'm2'
-  - types-aiobotocore-machinelearning>=2.25.0,<2.26.0 ; extra == 'machinelearning'
-  - types-aiobotocore-macie2>=2.25.0,<2.26.0 ; extra == 'macie2'
-  - types-aiobotocore-mailmanager>=2.25.0,<2.26.0 ; extra == 'mailmanager'
-  - types-aiobotocore-managedblockchain>=2.25.0,<2.26.0 ; extra == 'managedblockchain'
-  - types-aiobotocore-managedblockchain-query>=2.25.0,<2.26.0 ; extra == 'managedblockchain-query'
-  - types-aiobotocore-marketplace-agreement>=2.25.0,<2.26.0 ; extra == 'marketplace-agreement'
-  - types-aiobotocore-marketplace-catalog>=2.25.0,<2.26.0 ; extra == 'marketplace-catalog'
-  - types-aiobotocore-marketplace-deployment>=2.25.0,<2.26.0 ; extra == 'marketplace-deployment'
-  - types-aiobotocore-marketplace-entitlement>=2.25.0,<2.26.0 ; extra == 'marketplace-entitlement'
-  - types-aiobotocore-marketplace-reporting>=2.25.0,<2.26.0 ; extra == 'marketplace-reporting'
-  - types-aiobotocore-marketplacecommerceanalytics>=2.25.0,<2.26.0 ; extra == 'marketplacecommerceanalytics'
-  - types-aiobotocore-mediaconnect>=2.25.0,<2.26.0 ; extra == 'mediaconnect'
-  - types-aiobotocore-mediaconvert>=2.25.0,<2.26.0 ; extra == 'mediaconvert'
-  - types-aiobotocore-medialive>=2.25.0,<2.26.0 ; extra == 'medialive'
-  - types-aiobotocore-mediapackage>=2.25.0,<2.26.0 ; extra == 'mediapackage'
-  - types-aiobotocore-mediapackage-vod>=2.25.0,<2.26.0 ; extra == 'mediapackage-vod'
-  - types-aiobotocore-mediapackagev2>=2.25.0,<2.26.0 ; extra == 'mediapackagev2'
-  - types-aiobotocore-mediastore>=2.25.0,<2.26.0 ; extra == 'mediastore'
-  - types-aiobotocore-mediastore-data>=2.25.0,<2.26.0 ; extra == 'mediastore-data'
-  - types-aiobotocore-mediatailor>=2.25.0,<2.26.0 ; extra == 'mediatailor'
-  - types-aiobotocore-medical-imaging>=2.25.0,<2.26.0 ; extra == 'medical-imaging'
-  - types-aiobotocore-memorydb>=2.25.0,<2.26.0 ; extra == 'memorydb'
-  - types-aiobotocore-meteringmarketplace>=2.25.0,<2.26.0 ; extra == 'meteringmarketplace'
-  - types-aiobotocore-mgh>=2.25.0,<2.26.0 ; extra == 'mgh'
-  - types-aiobotocore-mgn>=2.25.0,<2.26.0 ; extra == 'mgn'
-  - types-aiobotocore-migration-hub-refactor-spaces>=2.25.0,<2.26.0 ; extra == 'migration-hub-refactor-spaces'
-  - types-aiobotocore-migrationhub-config>=2.25.0,<2.26.0 ; extra == 'migrationhub-config'
-  - types-aiobotocore-migrationhuborchestrator>=2.25.0,<2.26.0 ; extra == 'migrationhuborchestrator'
-  - types-aiobotocore-migrationhubstrategy>=2.25.0,<2.26.0 ; extra == 'migrationhubstrategy'
-  - types-aiobotocore-mpa>=2.25.0,<2.26.0 ; extra == 'mpa'
-  - types-aiobotocore-mq>=2.25.0,<2.26.0 ; extra == 'mq'
-  - types-aiobotocore-mturk>=2.25.0,<2.26.0 ; extra == 'mturk'
-  - types-aiobotocore-mwaa>=2.25.0,<2.26.0 ; extra == 'mwaa'
-  - types-aiobotocore-neptune>=2.25.0,<2.26.0 ; extra == 'neptune'
-  - types-aiobotocore-neptune-graph>=2.25.0,<2.26.0 ; extra == 'neptune-graph'
-  - types-aiobotocore-neptunedata>=2.25.0,<2.26.0 ; extra == 'neptunedata'
-  - types-aiobotocore-network-firewall>=2.25.0,<2.26.0 ; extra == 'network-firewall'
-  - types-aiobotocore-networkflowmonitor>=2.25.0,<2.26.0 ; extra == 'networkflowmonitor'
-  - types-aiobotocore-networkmanager>=2.25.0,<2.26.0 ; extra == 'networkmanager'
-  - types-aiobotocore-networkmonitor>=2.25.0,<2.26.0 ; extra == 'networkmonitor'
-  - types-aiobotocore-notifications>=2.25.0,<2.26.0 ; extra == 'notifications'
-  - types-aiobotocore-notificationscontacts>=2.25.0,<2.26.0 ; extra == 'notificationscontacts'
-  - types-aiobotocore-oam>=2.25.0,<2.26.0 ; extra == 'oam'
-  - types-aiobotocore-observabilityadmin>=2.25.0,<2.26.0 ; extra == 'observabilityadmin'
-  - types-aiobotocore-odb>=2.25.0,<2.26.0 ; extra == 'odb'
-  - types-aiobotocore-omics>=2.25.0,<2.26.0 ; extra == 'omics'
-  - types-aiobotocore-opensearch>=2.25.0,<2.26.0 ; extra == 'opensearch'
-  - types-aiobotocore-opensearchserverless>=2.25.0,<2.26.0 ; extra == 'opensearchserverless'
-  - types-aiobotocore-organizations>=2.25.0,<2.26.0 ; extra == 'organizations'
-  - types-aiobotocore-osis>=2.25.0,<2.26.0 ; extra == 'osis'
-  - types-aiobotocore-outposts>=2.25.0,<2.26.0 ; extra == 'outposts'
-  - types-aiobotocore-panorama>=2.25.0,<2.26.0 ; extra == 'panorama'
-  - types-aiobotocore-partnercentral-selling>=2.25.0,<2.26.0 ; extra == 'partnercentral-selling'
-  - types-aiobotocore-payment-cryptography>=2.25.0,<2.26.0 ; extra == 'payment-cryptography'
-  - types-aiobotocore-payment-cryptography-data>=2.25.0,<2.26.0 ; extra == 'payment-cryptography-data'
-  - types-aiobotocore-pca-connector-ad>=2.25.0,<2.26.0 ; extra == 'pca-connector-ad'
-  - types-aiobotocore-pca-connector-scep>=2.25.0,<2.26.0 ; extra == 'pca-connector-scep'
-  - types-aiobotocore-pcs>=2.25.0,<2.26.0 ; extra == 'pcs'
-  - types-aiobotocore-personalize>=2.25.0,<2.26.0 ; extra == 'personalize'
-  - types-aiobotocore-personalize-events>=2.25.0,<2.26.0 ; extra == 'personalize-events'
-  - types-aiobotocore-personalize-runtime>=2.25.0,<2.26.0 ; extra == 'personalize-runtime'
-  - types-aiobotocore-pi>=2.25.0,<2.26.0 ; extra == 'pi'
-  - types-aiobotocore-pinpoint>=2.25.0,<2.26.0 ; extra == 'pinpoint'
-  - types-aiobotocore-pinpoint-email>=2.25.0,<2.26.0 ; extra == 'pinpoint-email'
-  - types-aiobotocore-pinpoint-sms-voice>=2.25.0,<2.26.0 ; extra == 'pinpoint-sms-voice'
-  - types-aiobotocore-pinpoint-sms-voice-v2>=2.25.0,<2.26.0 ; extra == 'pinpoint-sms-voice-v2'
-  - types-aiobotocore-pipes>=2.25.0,<2.26.0 ; extra == 'pipes'
-  - types-aiobotocore-polly>=2.25.0,<2.26.0 ; extra == 'polly'
-  - types-aiobotocore-pricing>=2.25.0,<2.26.0 ; extra == 'pricing'
-  - types-aiobotocore-proton>=2.25.0,<2.26.0 ; extra == 'proton'
-  - types-aiobotocore-qapps>=2.25.0,<2.26.0 ; extra == 'qapps'
-  - types-aiobotocore-qbusiness>=2.25.0,<2.26.0 ; extra == 'qbusiness'
-  - types-aiobotocore-qconnect>=2.25.0,<2.26.0 ; extra == 'qconnect'
-  - types-aiobotocore-quicksight>=2.25.0,<2.26.0 ; extra == 'quicksight'
-  - types-aiobotocore-ram>=2.25.0,<2.26.0 ; extra == 'ram'
-  - types-aiobotocore-rbin>=2.25.0,<2.26.0 ; extra == 'rbin'
-  - types-aiobotocore-rds>=2.25.0,<2.26.0 ; extra == 'rds'
-  - types-aiobotocore-rds-data>=2.25.0,<2.26.0 ; extra == 'rds-data'
-  - types-aiobotocore-redshift>=2.25.0,<2.26.0 ; extra == 'redshift'
-  - types-aiobotocore-redshift-data>=2.25.0,<2.26.0 ; extra == 'redshift-data'
-  - types-aiobotocore-redshift-serverless>=2.25.0,<2.26.0 ; extra == 'redshift-serverless'
-  - types-aiobotocore-rekognition>=2.25.0,<2.26.0 ; extra == 'rekognition'
-  - types-aiobotocore-repostspace>=2.25.0,<2.26.0 ; extra == 'repostspace'
-  - types-aiobotocore-resiliencehub>=2.25.0,<2.26.0 ; extra == 'resiliencehub'
-  - types-aiobotocore-resource-explorer-2>=2.25.0,<2.26.0 ; extra == 'resource-explorer-2'
-  - types-aiobotocore-resource-groups>=2.25.0,<2.26.0 ; extra == 'resource-groups'
-  - types-aiobotocore-resourcegroupstaggingapi>=2.25.0,<2.26.0 ; extra == 'resourcegroupstaggingapi'
-  - types-aiobotocore-rolesanywhere>=2.25.0,<2.26.0 ; extra == 'rolesanywhere'
-  - types-aiobotocore-route53>=2.25.0,<2.26.0 ; extra == 'route53'
-  - types-aiobotocore-route53-recovery-cluster>=2.25.0,<2.26.0 ; extra == 'route53-recovery-cluster'
-  - types-aiobotocore-route53-recovery-control-config>=2.25.0,<2.26.0 ; extra == 'route53-recovery-control-config'
-  - types-aiobotocore-route53-recovery-readiness>=2.25.0,<2.26.0 ; extra == 'route53-recovery-readiness'
-  - types-aiobotocore-route53domains>=2.25.0,<2.26.0 ; extra == 'route53domains'
-  - types-aiobotocore-route53profiles>=2.25.0,<2.26.0 ; extra == 'route53profiles'
-  - types-aiobotocore-route53resolver>=2.25.0,<2.26.0 ; extra == 'route53resolver'
-  - types-aiobotocore-rtbfabric>=2.25.0,<2.26.0 ; extra == 'rtbfabric'
-  - types-aiobotocore-rum>=2.25.0,<2.26.0 ; extra == 'rum'
-  - types-aiobotocore-s3>=2.25.0,<2.26.0 ; extra == 's3'
-  - types-aiobotocore-s3control>=2.25.0,<2.26.0 ; extra == 's3control'
-  - types-aiobotocore-s3outposts>=2.25.0,<2.26.0 ; extra == 's3outposts'
-  - types-aiobotocore-s3tables>=2.25.0,<2.26.0 ; extra == 's3tables'
-  - types-aiobotocore-s3vectors>=2.25.0,<2.26.0 ; extra == 's3vectors'
-  - types-aiobotocore-sagemaker>=2.25.0,<2.26.0 ; extra == 'sagemaker'
-  - types-aiobotocore-sagemaker-a2i-runtime>=2.25.0,<2.26.0 ; extra == 'sagemaker-a2i-runtime'
-  - types-aiobotocore-sagemaker-edge>=2.25.0,<2.26.0 ; extra == 'sagemaker-edge'
-  - types-aiobotocore-sagemaker-featurestore-runtime>=2.25.0,<2.26.0 ; extra == 'sagemaker-featurestore-runtime'
-  - types-aiobotocore-sagemaker-geospatial>=2.25.0,<2.26.0 ; extra == 'sagemaker-geospatial'
-  - types-aiobotocore-sagemaker-metrics>=2.25.0,<2.26.0 ; extra == 'sagemaker-metrics'
-  - types-aiobotocore-sagemaker-runtime>=2.25.0,<2.26.0 ; extra == 'sagemaker-runtime'
-  - types-aiobotocore-savingsplans>=2.25.0,<2.26.0 ; extra == 'savingsplans'
-  - types-aiobotocore-scheduler>=2.25.0,<2.26.0 ; extra == 'scheduler'
-  - types-aiobotocore-schemas>=2.25.0,<2.26.0 ; extra == 'schemas'
-  - types-aiobotocore-sdb>=2.25.0,<2.26.0 ; extra == 'sdb'
-  - types-aiobotocore-secretsmanager>=2.25.0,<2.26.0 ; extra == 'secretsmanager'
-  - types-aiobotocore-security-ir>=2.25.0,<2.26.0 ; extra == 'security-ir'
-  - types-aiobotocore-securityhub>=2.25.0,<2.26.0 ; extra == 'securityhub'
-  - types-aiobotocore-securitylake>=2.25.0,<2.26.0 ; extra == 'securitylake'
-  - types-aiobotocore-serverlessrepo>=2.25.0,<2.26.0 ; extra == 'serverlessrepo'
-  - types-aiobotocore-service-quotas>=2.25.0,<2.26.0 ; extra == 'service-quotas'
-  - types-aiobotocore-servicecatalog>=2.25.0,<2.26.0 ; extra == 'servicecatalog'
-  - types-aiobotocore-servicecatalog-appregistry>=2.25.0,<2.26.0 ; extra == 'servicecatalog-appregistry'
-  - types-aiobotocore-servicediscovery>=2.25.0,<2.26.0 ; extra == 'servicediscovery'
-  - types-aiobotocore-ses>=2.25.0,<2.26.0 ; extra == 'ses'
-  - types-aiobotocore-sesv2>=2.25.0,<2.26.0 ; extra == 'sesv2'
-  - types-aiobotocore-shield>=2.25.0,<2.26.0 ; extra == 'shield'
-  - types-aiobotocore-signer>=2.25.0,<2.26.0 ; extra == 'signer'
-  - types-aiobotocore-simspaceweaver>=2.25.0,<2.26.0 ; extra == 'simspaceweaver'
-  - types-aiobotocore-snow-device-management>=2.25.0,<2.26.0 ; extra == 'snow-device-management'
-  - types-aiobotocore-snowball>=2.25.0,<2.26.0 ; extra == 'snowball'
-  - types-aiobotocore-sns>=2.25.0,<2.26.0 ; extra == 'sns'
-  - types-aiobotocore-socialmessaging>=2.25.0,<2.26.0 ; extra == 'socialmessaging'
-  - types-aiobotocore-sqs>=2.25.0,<2.26.0 ; extra == 'sqs'
-  - types-aiobotocore-ssm>=2.25.0,<2.26.0 ; extra == 'ssm'
-  - types-aiobotocore-ssm-contacts>=2.25.0,<2.26.0 ; extra == 'ssm-contacts'
-  - types-aiobotocore-ssm-guiconnect>=2.25.0,<2.26.0 ; extra == 'ssm-guiconnect'
-  - types-aiobotocore-ssm-incidents>=2.25.0,<2.26.0 ; extra == 'ssm-incidents'
-  - types-aiobotocore-ssm-quicksetup>=2.25.0,<2.26.0 ; extra == 'ssm-quicksetup'
-  - types-aiobotocore-ssm-sap>=2.25.0,<2.26.0 ; extra == 'ssm-sap'
-  - types-aiobotocore-sso>=2.25.0,<2.26.0 ; extra == 'sso'
-  - types-aiobotocore-sso-admin>=2.25.0,<2.26.0 ; extra == 'sso-admin'
-  - types-aiobotocore-sso-oidc>=2.25.0,<2.26.0 ; extra == 'sso-oidc'
-  - types-aiobotocore-stepfunctions>=2.25.0,<2.26.0 ; extra == 'stepfunctions'
-  - types-aiobotocore-storagegateway>=2.25.0,<2.26.0 ; extra == 'storagegateway'
-  - types-aiobotocore-sts>=2.25.0,<2.26.0 ; extra == 'sts'
-  - types-aiobotocore-supplychain>=2.25.0,<2.26.0 ; extra == 'supplychain'
-  - types-aiobotocore-support>=2.25.0,<2.26.0 ; extra == 'support'
-  - types-aiobotocore-support-app>=2.25.0,<2.26.0 ; extra == 'support-app'
-  - types-aiobotocore-swf>=2.25.0,<2.26.0 ; extra == 'swf'
-  - types-aiobotocore-synthetics>=2.25.0,<2.26.0 ; extra == 'synthetics'
-  - types-aiobotocore-taxsettings>=2.25.0,<2.26.0 ; extra == 'taxsettings'
-  - types-aiobotocore-textract>=2.25.0,<2.26.0 ; extra == 'textract'
-  - types-aiobotocore-timestream-influxdb>=2.25.0,<2.26.0 ; extra == 'timestream-influxdb'
-  - types-aiobotocore-timestream-query>=2.25.0,<2.26.0 ; extra == 'timestream-query'
-  - types-aiobotocore-timestream-write>=2.25.0,<2.26.0 ; extra == 'timestream-write'
-  - types-aiobotocore-tnb>=2.25.0,<2.26.0 ; extra == 'tnb'
-  - types-aiobotocore-transcribe>=2.25.0,<2.26.0 ; extra == 'transcribe'
-  - types-aiobotocore-transfer>=2.25.0,<2.26.0 ; extra == 'transfer'
-  - types-aiobotocore-translate>=2.25.0,<2.26.0 ; extra == 'translate'
-  - types-aiobotocore-trustedadvisor>=2.25.0,<2.26.0 ; extra == 'trustedadvisor'
-  - types-aiobotocore-verifiedpermissions>=2.25.0,<2.26.0 ; extra == 'verifiedpermissions'
-  - types-aiobotocore-voice-id>=2.25.0,<2.26.0 ; extra == 'voice-id'
-  - types-aiobotocore-vpc-lattice>=2.25.0,<2.26.0 ; extra == 'vpc-lattice'
-  - types-aiobotocore-waf>=2.25.0,<2.26.0 ; extra == 'waf'
-  - types-aiobotocore-waf-regional>=2.25.0,<2.26.0 ; extra == 'waf-regional'
-  - types-aiobotocore-wafv2>=2.25.0,<2.26.0 ; extra == 'wafv2'
-  - types-aiobotocore-wellarchitected>=2.25.0,<2.26.0 ; extra == 'wellarchitected'
-  - types-aiobotocore-wisdom>=2.25.0,<2.26.0 ; extra == 'wisdom'
-  - types-aiobotocore-workdocs>=2.25.0,<2.26.0 ; extra == 'workdocs'
-  - types-aiobotocore-workmail>=2.25.0,<2.26.0 ; extra == 'workmail'
-  - types-aiobotocore-workmailmessageflow>=2.25.0,<2.26.0 ; extra == 'workmailmessageflow'
-  - types-aiobotocore-workspaces>=2.25.0,<2.26.0 ; extra == 'workspaces'
-  - types-aiobotocore-workspaces-instances>=2.25.0,<2.26.0 ; extra == 'workspaces-instances'
-  - types-aiobotocore-workspaces-thin-client>=2.25.0,<2.26.0 ; extra == 'workspaces-thin-client'
-  - types-aiobotocore-workspaces-web>=2.25.0,<2.26.0 ; extra == 'workspaces-web'
-  - types-aiobotocore-xray>=2.25.0,<2.26.0 ; extra == 'xray'
+  - conda-forge-metadata>=0.12.0
+  - conda-oci-mirror @ git+https://github.com/channel-mirrors/conda-oci-mirror.git@25ea3e436f0b0bc5a9c646121efafc9c68e116cd
+  requires_python: ==3.12
+- pypi: git+https://github.com/channel-mirrors/conda-oci-mirror.git?rev=25ea3e436f0b0bc5a9c646121efafc9c68e116cd#25ea3e436f0b0bc5a9c646121efafc9c68e116cd
+  name: conda-oci-mirror
+  version: 0.1.0
+  requires_dist:
+  - click
+  - requests
+  - oras==0.1.14
+  - conda-package-handling
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/0f/73/bb1bc2529f852e7bf64a2dec885e89ff9f5cc7bbf6c9340eed30ff2c69c5/ruamel.yaml-0.18.16-py3-none-any.whl
+  name: ruamel-yaml
+  version: 0.18.16
+  sha256: 048f26d64245bae57a4f9ef6feb5b552a386830ef7a826f235ffb804c59efbba
+  requires_dist:
+  - ruamel-yaml-clib>=0.2.7 ; python_full_version < '3.14' and platform_python_implementation == 'CPython'
+  - ruamel-yaml-jinja2>=0.2 ; extra == 'jinja2'
+  - ryd ; extra == 'docs'
+  - mercurial>5.7 ; extra == 'docs'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/10/a9/121aa64e09dd869422a65158a9df596d0750460baac11085bca3d1444795/oras-0.1.14-py3-none-any.whl
+  name: oras
+  version: 0.1.14
+  sha256: a3cf01cd279d507fb7fd2df7723a3fa1633955099fb3d412abe76cbe2ee10743
+  requires_dist:
+  - jsonschema
+  - requests
+  - jsonschema ; extra == 'all'
+  - requests ; extra == 'all'
+  - pytest>=4.6.2 ; extra == 'all'
+  - mypy ; extra == 'all'
+  - pyflakes ; extra == 'all'
+  - black ; extra == 'all'
+  - types-requests ; extra == 'all'
+  - isort ; extra == 'all'
+  - docker==5.0.1 ; extra == 'all'
+  - docker==5.0.1 ; extra == 'docker'
+  - pytest>=4.6.2 ; extra == 'tests'
+  - mypy ; extra == 'tests'
+  - pyflakes ; extra == 'tests'
+  - black ; extra == 'tests'
+  - types-requests ; extra == 'tests'
+  - isort ; extra == 'tests'
+- pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
+  name: soupsieve
+  version: '2.8'
+  sha256: 0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+  name: beautifulsoup4
+  version: 4.14.3
+  sha256: 0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb
+  requires_dist:
+  - soupsieve>=1.6.1
+  - typing-extensions>=4.0.0
+  - cchardet ; extra == 'cchardet'
+  - chardet ; extra == 'chardet'
+  - charset-normalizer ; extra == 'charset-normalizer'
+  - html5lib ; extra == 'html5lib'
+  - lxml ; extra == 'lxml'
+  requires_python: '>=3.7.0'
+- pypi: https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl
+  name: responses
+  version: 0.25.8
+  sha256: 0c710af92def29c8352ceadff0c3fe340ace27cf5af1bbe46fb71275bcd2831c
+  requires_dist:
+  - requests>=2.30.0,<3.0
+  - urllib3>=1.25.10,<3.0
+  - pyyaml
+  - pytest>=7.0.0 ; extra == 'tests'
+  - coverage>=6.0.0 ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-asyncio ; extra == 'tests'
+  - pytest-httpserver ; extra == 'tests'
+  - flake8 ; extra == 'tests'
+  - types-pyyaml ; extra == 'tests'
+  - types-requests ; extra == 'tests'
+  - mypy ; extra == 'tests'
+  - tomli-w ; extra == 'tests'
+  - tomli ; python_full_version < '3.11' and extra == 'tests'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+  name: referencing
+  version: 0.37.0
+  sha256: 381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231
+  requires_dist:
+  - attrs>=22.2.0
+  - rpds-py>=0.7.0
+  - typing-extensions>=4.4.0 ; python_full_version < '3.13'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl
+  name: werkzeug
+  version: 3.1.4
+  sha256: 2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905
+  requires_dist:
+  - markupsafe>=2.1.1
+  - watchdog>=2.3 ; extra == 'watchdog'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl
+  name: rpds-py
+  version: 0.30.0
+  sha256: a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: markupsafe
+  version: 3.0.3
+  sha256: d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+  name: jsonschema-specifications
+  version: 2025.9.1
+  sha256: 98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe
+  requires_dist:
+  - referencing>=0.31.0
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl
+  name: rpds-py
+  version: 0.30.0
+  sha256: 6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: rpds-py
+  version: 0.30.0
+  sha256: 47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: ruamel-yaml-clib
+  version: 0.2.15
+  sha256: 11e5499db1ccbc7f4b41f0565e4f799d863ea720e01d3e99fa0b7b5fcd7802c9
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+  name: jinja2
+  version: 3.1.6
+  sha256: 85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
+  requires_dist:
+  - markupsafe>=2.0
+  - babel>=2.7 ; extra == 'i18n'
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/66/24/845d560e657dbede375c8d924eaad6e63c01b1bebc04aff70a0c2cf89cef/conda_package_handling-2.4.0-py3-none-any.whl
+  name: conda-package-handling
+  version: 2.4.0
+  sha256: f835b17a5d8283555e13e0e7b7af80770007a1ff4924b07994aedad96bfb5e0c
+  requires_dist:
+  - conda-package-streaming>=0.9.0
+  - furo ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - sphinx-argparse ; extra == 'docs'
+  - myst-parser ; extra == 'docs'
+  - mdit-py-plugins>=0.3.0 ; extra == 'docs'
+  - mock ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - bottle ; extra == 'test'
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/74/a3/8eaef3dd748e0b2db5515cd9d01fd058dedf401ed9cf183cf9611e0883c0/types_aiobotocore-3.0.0-py3-none-any.whl
   name: types-aiobotocore
@@ -5483,337 +5055,187 @@ packages:
   - types-aiobotocore-workspaces-web>=3.0.0,<3.1.0 ; extra == 'workspaces-web'
   - types-aiobotocore-xray>=3.0.0,<3.1.0 ; extra == 'xray'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.28.4-pyhd8ed1ab_0.conda
-  sha256: 3da1da9f2f4321b5a0a003e358b60473315589d7ed3a9b9a1eda15c3d53d194e
-  md5: 99c349ad1a20d8a5be2fe155f91d8b3c
-  depends:
-  - pip
-  - python >=3.10,<4.0
-  license: MIT
-  purls:
-  - pkg:pypi/types-awscrt?source=hash-mapping
-  size: 22433
-  timestamp: 1762832622189
-- conda: https://conda.anaconda.org/conda-forge/noarch/types-deprecated-1.2.15.20250304-pyhd8ed1ab_0.conda
-  sha256: d1ee3d82ab6043a7049f9f0599cec6b1347bd6a25c3d316225ba89b96d478be7
-  md5: 13d2a2b51f639360031a30fa011199fc
-  depends:
-  - python >=3.9
-  license: Apache-2.0 AND MIT
-  purls:
-  - pkg:pypi/types-deprecated?source=hash-mapping
-  size: 17824
-  timestamp: 1741080900085
-- conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
-  sha256: ba565f80b5dc5d88f34587b391f21807efd54099516f11beae5cb29a7925fd3d
-  md5: 0fcb42ddc8e8ba6f906274108e6d891d
-  depends:
-  - python >=3.10
-  license: Apache-2.0 AND MIT
-  purls:
-  - pkg:pypi/types-pyyaml?source=compressed-mapping
-  size: 22060
-  timestamp: 1762942278334
-- conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.20240406-pyhd8ed1ab_0.conda
-  sha256: de93470fe64b2baa5f8ef16a6edf849bb93542f301ed343d0ab4d6fd6116d742
-  md5: b4bc9b6dbc54191100b518a18be6045e
-  depends:
-  - python >=3.6
-  - urllib3 >=2
-  license: Apache-2.0 AND MIT
-  purls:
-  - pkg:pypi/types-requests?source=hash-mapping
-  size: 26072
-  timestamp: 1712378106245
-- conda: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.14.0-pyhcf101f3_0.conda
-  sha256: c80bc9562af94f62c311eaa3eb0040c8660bed7301a7aa4f463d48ce404a8fdc
-  md5: 7ee7f6ac4c1d34c05b21210cabc61871
-  depends:
-  - python >=3.10
-  - types-awscrt
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/types-s3transfer?source=hash-mapping
-  size: 19446
-  timestamp: 1760383865409
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-  sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
-  md5: edd329d7d3a4ab45dcf905899a7a6115
-  depends:
-  - typing_extensions ==4.15.0 pyhcf101f3_0
-  license: PSF-2.0
-  license_family: PSF
-  purls: []
-  size: 91383
-  timestamp: 1756220668932
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_0.conda
-  sha256: 8aaf69b828c2b94d0784f18f70f11aa032950d304e57e88467120b45c18c24fd
-  md5: 399701494e731ce73fdd86c185a3d1b4
-  depends:
-  - python >=3.10
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/typing-inspection?source=compressed-mapping
-  size: 18799
-  timestamp: 1759301271883
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
-  md5: 0caa1af407ecff61170c9437a808404d
-  depends:
-  - python >=3.10
-  - python
-  license: PSF-2.0
-  license_family: PSF
-  purls:
-  - pkg:pypi/typing-extensions?source=hash-mapping
-  size: 51692
-  timestamp: 1756220668932
-- conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.39.1-hdab8a38_0.conda
-  sha256: 1d46b85459276f0ff5d25eaf7d4c4b7434580f41f6748505376791d3894777e4
-  md5: ae3ecc640ffae55a243aba57f4a34060
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 3360083
-  timestamp: 1762998892995
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.39.1-hd1458d2_0.conda
-  sha256: 44a86478536cc40ad4234a4732eb099811c5d83a961efa5ea5f75ae604cadd73
-  md5: f4aa5c348f4f0cc1b774cdaf9d5c1222
-  depends:
-  - __osx >=11.0
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 3004203
-  timestamp: 1762999586830
-- conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.39.1-h77a83cd_0.conda
-  sha256: 2b5b7f62abcb72c54a068402d6664d5410f9813a85f43cb926f47987ff217f00
-  md5: b3a39ae6a43115b311fe8c243851319f
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 2846362
-  timestamp: 1762999439525
-- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-  sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
-  md5: 4222072737ccff51314b5ece9c7d6f5a
-  license: LicenseRef-Public-Domain
-  purls: []
-  size: 122968
-  timestamp: 1742727099393
-- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
-  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
-  md5: 71b24316859acd00bdb8b38f5e2ce328
-  constrains:
-  - vc14_runtime >=14.29.30037
-  - vs2015_runtime >=14.29.30037
-  license: LicenseRef-MicrosoftWindowsSDK10
-  purls: []
-  size: 694692
-  timestamp: 1756385147981
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312hd9148b4_6.conda
-  sha256: e1ecdfe8b0df725436e1d307e8672010d92b9aa96148f21ddf9be9b9596c75b0
-  md5: f30ece80e76f9cc96e30cc5c71d2818e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cffi
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ukkonen?source=hash-mapping
-  size: 14602
-  timestamp: 1761594857801
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312ha0dd364_6.conda
-  sha256: ba54fd3c178d30816fff864e5f6c7d05d4ec5f72a42ad15ec576a81fe28bea48
-  md5: 678a837ca1469257c13895124d4055b8
-  depends:
-  - __osx >=11.0
-  - cffi
-  - libcxx >=19
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ukkonen?source=hash-mapping
-  size: 14510
-  timestamp: 1761595134634
-- conda: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py312hf90b1b7_6.conda
-  sha256: 2b41d4e8243e31e8be51fa5cebc3f8017ecc7ed388af4e9498f97863459ec4e1
-  md5: 7369aaa9123f029c7aee5f34381f7742
-  depends:
-  - cffi
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ukkonen?source=hash-mapping
-  size: 18206
-  timestamp: 1761595067912
-- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
-  sha256: 4fb9789154bd666ca74e428d973df81087a697dbb987775bc3198d2215f240f8
-  md5: 436c165519e140cb08d246a4472a9d6a
-  depends:
-  - brotli-python >=1.0.9
-  - h2 >=4,<5
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.9
-  - zstandard >=0.18.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/urllib3?source=hash-mapping
-  size: 101735
-  timestamp: 1750271478254
-- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
-  sha256: 82250af59af9ff3c6a635dd4c4764c631d854feb334d6747d356d949af44d7cf
-  md5: ef02bbe151253a72b8eda264a935db66
-  depends:
-  - vc14_runtime >=14.42.34433
-  track_features:
-  - vc14
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 18861
-  timestamp: 1760418772353
-- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
-  sha256: e3a3656b70d1202e0d042811ceb743bd0d9f7e00e2acdf824d231b044ef6c0fd
-  md5: 378d5dcec45eaea8d303da6f00447ac0
-  depends:
-  - ucrt >=10.0.20348.0
-  - vcomp14 14.44.35208 h818238b_32
-  constrains:
-  - vs2015_runtime 14.44.35208.* *_32
-  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
-  license_family: Proprietary
-  purls: []
-  size: 682706
-  timestamp: 1760418629729
-- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
-  sha256: f3790c88fbbdc55874f41de81a4237b1b91eab75e05d0e58661518ff04d2a8a1
-  md5: 58f67b437acbf2764317ba273d731f1d
-  depends:
-  - ucrt >=10.0.20348.0
-  constrains:
-  - vs2015_runtime 14.44.35208.* *_32
-  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
-  license_family: Proprietary
-  purls: []
-  size: 114846
-  timestamp: 1760418593847
-- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
-  sha256: 77193c99c6626c58446168d3700f9643d8c0dab1f6deb6b9dd039e6872781bfb
-  md5: cfccfd4e8d9de82ed75c8e2c91cab375
-  depends:
-  - distlib >=0.3.7,<1
-  - filelock >=3.12.2,<4
-  - platformdirs >=3.9.1,<5
-  - python >=3.10
-  - typing_extensions >=4.13.2
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/virtualenv?source=hash-mapping
-  size: 4401341
-  timestamp: 1761726489722
-- pypi: https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl
-  name: werkzeug
-  version: 3.1.4
-  sha256: 2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905
+- pypi: https://files.pythonhosted.org/packages/83/d4/6991df072b34741a0c115e8d21dc2fe142e4b497319d762e957f6677f001/moto-5.1.18-py3-none-any.whl
+  name: moto
+  version: 5.1.18
+  sha256: b65aa8fc9032c5c574415451e14fd7da4e43fd50b8bdcb5f10289ad382c25bcf
   requires_dist:
-  - markupsafe>=2.1.1
-  - watchdog>=2.3 ; extra == 'watchdog'
+  - boto3>=1.9.201
+  - botocore>=1.20.88,!=1.35.45,!=1.35.46
+  - cryptography>=35.0.0
+  - requests>=2.5
+  - xmltodict
+  - werkzeug>=0.5,!=2.2.0,!=2.2.1
+  - python-dateutil>=2.1,<3.0.0
+  - responses>=0.15.0,!=0.25.5
+  - jinja2>=2.10.1
+  - antlr4-python3-runtime ; extra == 'all'
+  - joserfc>=0.9.0 ; extra == 'all'
+  - jsonpath-ng ; extra == 'all'
+  - docker>=3.0.0 ; extra == 'all'
+  - graphql-core ; extra == 'all'
+  - pyyaml>=5.1 ; extra == 'all'
+  - cfn-lint>=0.40.0 ; extra == 'all'
+  - jsonschema ; extra == 'all'
+  - openapi-spec-validator>=0.5.0 ; extra == 'all'
+  - pyparsing>=3.0.7 ; extra == 'all'
+  - py-partiql-parser==0.6.3 ; extra == 'all'
+  - aws-xray-sdk>=0.93,!=0.96 ; extra == 'all'
+  - setuptools ; extra == 'all'
+  - multipart ; extra == 'all'
+  - antlr4-python3-runtime ; extra == 'proxy'
+  - joserfc>=0.9.0 ; extra == 'proxy'
+  - jsonpath-ng ; extra == 'proxy'
+  - docker>=2.5.1 ; extra == 'proxy'
+  - graphql-core ; extra == 'proxy'
+  - pyyaml>=5.1 ; extra == 'proxy'
+  - cfn-lint>=0.40.0 ; extra == 'proxy'
+  - openapi-spec-validator>=0.5.0 ; extra == 'proxy'
+  - pyparsing>=3.0.7 ; extra == 'proxy'
+  - py-partiql-parser==0.6.3 ; extra == 'proxy'
+  - aws-xray-sdk>=0.93,!=0.96 ; extra == 'proxy'
+  - setuptools ; extra == 'proxy'
+  - multipart ; extra == 'proxy'
+  - antlr4-python3-runtime ; extra == 'server'
+  - joserfc>=0.9.0 ; extra == 'server'
+  - jsonpath-ng ; extra == 'server'
+  - docker>=3.0.0 ; extra == 'server'
+  - graphql-core ; extra == 'server'
+  - pyyaml>=5.1 ; extra == 'server'
+  - cfn-lint>=0.40.0 ; extra == 'server'
+  - openapi-spec-validator>=0.5.0 ; extra == 'server'
+  - pyparsing>=3.0.7 ; extra == 'server'
+  - py-partiql-parser==0.6.3 ; extra == 'server'
+  - aws-xray-sdk>=0.93,!=0.96 ; extra == 'server'
+  - setuptools ; extra == 'server'
+  - flask!=2.2.0,!=2.2.1 ; extra == 'server'
+  - flask-cors ; extra == 'server'
+  - pyyaml>=5.1 ; extra == 'apigateway'
+  - joserfc>=0.9.0 ; extra == 'apigateway'
+  - openapi-spec-validator>=0.5.0 ; extra == 'apigateway'
+  - pyyaml>=5.1 ; extra == 'apigatewayv2'
+  - openapi-spec-validator>=0.5.0 ; extra == 'apigatewayv2'
+  - graphql-core ; extra == 'appsync'
+  - docker>=3.0.0 ; extra == 'awslambda'
+  - docker>=3.0.0 ; extra == 'batch'
+  - joserfc>=0.9.0 ; extra == 'cloudformation'
+  - docker>=3.0.0 ; extra == 'cloudformation'
+  - graphql-core ; extra == 'cloudformation'
+  - pyyaml>=5.1 ; extra == 'cloudformation'
+  - cfn-lint>=0.40.0 ; extra == 'cloudformation'
+  - openapi-spec-validator>=0.5.0 ; extra == 'cloudformation'
+  - pyparsing>=3.0.7 ; extra == 'cloudformation'
+  - py-partiql-parser==0.6.3 ; extra == 'cloudformation'
+  - aws-xray-sdk>=0.93,!=0.96 ; extra == 'cloudformation'
+  - setuptools ; extra == 'cloudformation'
+  - joserfc>=0.9.0 ; extra == 'cognitoidp'
+  - docker>=3.0.0 ; extra == 'dynamodb'
+  - py-partiql-parser==0.6.3 ; extra == 'dynamodb'
+  - docker>=3.0.0 ; extra == 'dynamodbstreams'
+  - py-partiql-parser==0.6.3 ; extra == 'dynamodbstreams'
+  - jsonpath-ng ; extra == 'events'
+  - pyparsing>=3.0.7 ; extra == 'glue'
+  - jsonschema ; extra == 'quicksight'
+  - joserfc>=0.9.0 ; extra == 'resourcegroupstaggingapi'
+  - docker>=3.0.0 ; extra == 'resourcegroupstaggingapi'
+  - graphql-core ; extra == 'resourcegroupstaggingapi'
+  - pyyaml>=5.1 ; extra == 'resourcegroupstaggingapi'
+  - cfn-lint>=0.40.0 ; extra == 'resourcegroupstaggingapi'
+  - openapi-spec-validator>=0.5.0 ; extra == 'resourcegroupstaggingapi'
+  - pyparsing>=3.0.7 ; extra == 'resourcegroupstaggingapi'
+  - py-partiql-parser==0.6.3 ; extra == 'resourcegroupstaggingapi'
+  - pyyaml>=5.1 ; extra == 's3'
+  - py-partiql-parser==0.6.3 ; extra == 's3'
+  - pyyaml>=5.1 ; extra == 's3crc32c'
+  - py-partiql-parser==0.6.3 ; extra == 's3crc32c'
+  - crc32c ; extra == 's3crc32c'
+  - pyyaml>=5.1 ; extra == 'ssm'
+  - antlr4-python3-runtime ; extra == 'stepfunctions'
+  - jsonpath-ng ; extra == 'stepfunctions'
+  - aws-xray-sdk>=0.93,!=0.96 ; extra == 'xray'
+  - setuptools ; extra == 'xray'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
-  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
-  md5: 75cb7132eb58d97896e173ef12ac9986
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/wheel?source=hash-mapping
-  size: 62931
-  timestamp: 1733130309598
-- conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
-  sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
-  md5: 46e441ba871f524e2b067929da3051c2
-  depends:
-  - __win
-  - python >=3.9
-  license: LicenseRef-Public-Domain
-  purls:
-  - pkg:pypi/win-inet-pton?source=hash-mapping
-  size: 9555
-  timestamp: 1733130678956
-- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
-  sha256: 8320d5af37eb8933e5d129884ea013b2687e75b08aff5216193df3378eaea92f
-  md5: 8af3faf88325836e46c6cb79828e058c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/wrapt?source=hash-mapping
-  size: 64608
-  timestamp: 1756851740646
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.3-py312h163523d_1.conda
-  sha256: b2be8bbfc1d7d63cd82f23c6aab0845b5dbbd835378b3c4e61b80b7d81ae9656
-  md5: 5658c0733acef1e0e2701aa1ebaa1f14
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/wrapt?source=hash-mapping
-  size: 61948
-  timestamp: 1756851912789
-- conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.17.3-py312he06e257_1.conda
-  sha256: f9e9e28ef3a0564a5588427b9503ed08e5fe3624b8f8132d60383439a47baafc
-  md5: fc10fd823d05bde83cda9e90dbef34ed
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/wrapt?source=hash-mapping
-  size: 63012
-  timestamp: 1756852490793
+- pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+  name: deprecated
+  version: 1.3.1
+  sha256: 597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f
+  requires_dist:
+  - wrapt>=1.10,<3
+  - inspect2 ; python_full_version < '3'
+  - tox ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - bump2version<1 ; extra == 'dev'
+  - setuptools ; python_full_version >= '3.12' and extra == 'dev'
+  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+- pypi: https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl
+  name: ruamel-yaml-clib
+  version: 0.2.15
+  sha256: 64da03cbe93c1e91af133f5bec37fd24d0d4ba2418eaf970d7166b0a26a148a2
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/87/39/0bd20aa98ae43756b0bb5d8b055c19de842b422fe588eaa16f11dce1f399/conda_package_streaming-0.12.0-py3-none-any.whl
+  name: conda-package-streaming
+  version: 0.12.0
+  sha256: 45ae0ac0e198188703e845a42ac21292b73cd7077df358ea882d25923ab26f96
+  requires_dist:
+  - requests
+  - zstandard>=0.15
+  - furo ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - myst-parser ; extra == 'docs'
+  - mdit-py-plugins>=0.3.0 ; extra == 'docs'
+  - pytest>=7 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - boto3 ; extra == 'test'
+  - boto3-stubs[essential] ; extra == 'test'
+  - bottle ; extra == 'test'
+  - conda ; extra == 'test'
+  - conda-package-handling>=2 ; extra == 'test'
+  - responses ; extra == 'test'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
+  name: markupsafe
+  version: 3.0.3
+  sha256: 1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl
+  name: markupsafe
+  version: 3.0.3
+  sha256: 26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl
+  name: ruamel-yaml-clib
+  version: 0.2.15
+  sha256: 2b216904750889133d9222b7b873c199d48ecbb12912aca78970f84a5aa1a4bc
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
+  name: jsonschema
+  version: 4.25.1
+  sha256: 3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63
+  requires_dist:
+  - attrs>=22.2.0
+  - jsonschema-specifications>=2023.3.6
+  - referencing>=0.28.4
+  - rpds-py>=0.7.1
+  - fqdn ; extra == 'format'
+  - idna ; extra == 'format'
+  - isoduration ; extra == 'format'
+  - jsonpointer>1.13 ; extra == 'format'
+  - rfc3339-validator ; extra == 'format'
+  - rfc3987 ; extra == 'format'
+  - uri-template ; extra == 'format'
+  - webcolors>=1.11 ; extra == 'format'
+  - fqdn ; extra == 'format-nongpl'
+  - idna ; extra == 'format-nongpl'
+  - isoduration ; extra == 'format-nongpl'
+  - jsonpointer>1.13 ; extra == 'format-nongpl'
+  - rfc3339-validator ; extra == 'format-nongpl'
+  - rfc3986-validator>0.1.0 ; extra == 'format-nongpl'
+  - rfc3987-syntax>=1.1.0 ; extra == 'format-nongpl'
+  - uri-template ; extra == 'format-nongpl'
+  - webcolors>=24.6.0 ; extra == 'format-nongpl'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/c0/20/69a0e6058bc5ea74892d089d64dfc3a62ba78917ec5e2cfa70f7c92ba3a5/xmltodict-1.0.2-py3-none-any.whl
   name: xmltodict
   version: 1.0.2
@@ -5822,285 +5244,856 @@ packages:
   - pytest ; extra == 'test'
   - pytest-cov ; extra == 'test'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
-  sha256: 802725371682ea06053971db5b4fb7fbbcaee9cb1804ec688f55e51d74660617
-  md5: 68eae977d7d1196d32b636a026dc015d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - liblzma 5.8.1 hb9d3cd8_2
-  - liblzma-devel 5.8.1 hb9d3cd8_2
-  - xz-gpl-tools 5.8.1 hbcc6ac9_2
-  - xz-tools 5.8.1 hb9d3cd8_2
-  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
-  purls: []
-  size: 23987
-  timestamp: 1749230104359
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_2.conda
-  sha256: afb747cf017b67cc31d54c6e6c4bd1b1e179fe487a3d23a856232ed7fd0b099b
-  md5: 39435c82e5a007ef64cbb153ecc40cfd
-  depends:
-  - __osx >=11.0
-  - liblzma 5.8.1 h39f12f2_2
-  - liblzma-devel 5.8.1 h39f12f2_2
-  - xz-gpl-tools 5.8.1 h9a6d368_2
-  - xz-tools 5.8.1 h39f12f2_2
-  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
-  purls: []
-  size: 23995
-  timestamp: 1749230346887
-- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.8.1-h208afaa_2.conda
-  sha256: 22289a81da4698bb8d13ac032a88a4a1f49505b2303885e1add3d8bd1a7b56e6
-  md5: fb3fa84ea37de9f12cc8ba730cec0bdc
-  depends:
-  - liblzma 5.8.1 h2466b09_2
-  - liblzma-devel 5.8.1 h2466b09_2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz-tools 5.8.1 h2466b09_2
-  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
-  purls: []
-  size: 24430
-  timestamp: 1749230691276
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
-  sha256: 840838dca829ec53f1160f3fca6dbfc43f2388b85f15d3e867e69109b168b87b
-  md5: bf627c16aa26231720af037a2709ab09
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - liblzma 5.8.1 hb9d3cd8_2
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
-  purls: []
-  size: 33911
-  timestamp: 1749230090353
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_2.conda
-  sha256: a0790cfb48d240e7b655b0d797a00040219cf39e3ee38e2104e548515df4f9c2
-  md5: 09b1442c1d49ac7c5f758c44695e77d1
-  depends:
-  - __osx >=11.0
-  - liblzma 5.8.1 h39f12f2_2
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
-  purls: []
-  size: 34103
-  timestamp: 1749230329933
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
-  sha256: 58034f3fca491075c14e61568ad8b25de00cb3ae479de3e69be6d7ee5d3ace28
-  md5: 1bad2995c8f1c8075c6c331bf96e46fb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - liblzma 5.8.1 hb9d3cd8_2
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD AND LGPL-2.1-or-later
-  purls: []
-  size: 96433
-  timestamp: 1749230076687
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.1-h39f12f2_2.conda
-  sha256: 9d1232705e3d175f600dc8e344af9182d0341cdaa73d25330591a28532951063
-  md5: 37996935aa33138fca43e4b4563b6a28
-  depends:
-  - __osx >=11.0
-  - liblzma 5.8.1 h39f12f2_2
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD AND LGPL-2.1-or-later
-  purls: []
-  size: 86425
-  timestamp: 1749230316106
-- conda: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.8.1-h2466b09_2.conda
-  sha256: 38712f0e62f61741ab69d7551fa863099f5be769bdf9fdbc28542134874b4e88
-  md5: e1b62ec0457e6ba10287a49854108fdb
-  depends:
-  - liblzma 5.8.1 h2466b09_2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD AND LGPL-2.1-or-later
-  purls: []
-  size: 67419
-  timestamp: 1749230666460
-- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
-  sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
-  md5: a77f85f77be52ff59391544bfe73390a
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 85189
-  timestamp: 1753484064210
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
-  sha256: b03433b13d89f5567e828ea9f1a7d5c5d697bf374c28a4168d71e9464f5dafac
-  md5: 78a0fe9e9c50d2c381e8ee47e3ea437d
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 83386
-  timestamp: 1753484079473
-- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
-  sha256: 80ee68c1e7683a35295232ea79bcc87279d31ffeda04a1665efdb43cbd50a309
-  md5: 433699cba6602098ae8957a323da2664
-  depends:
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 63944
-  timestamp: 1753484092156
-- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.22.0-py312h8a5da7c_0.conda
-  sha256: 6e3f2db09387fc982b5400b842745084825cd2d4621e8278e4af8fb0dc2b55d8
-  md5: 6a3fd177315aaafd4366930d440e4430
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - idna >=2.0
-  - libgcc >=14
-  - multidict >=4.0
-  - propcache >=0.2.1
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/yarl?source=hash-mapping
-  size: 151549
-  timestamp: 1761337128623
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.22.0-py312h5748b74_0.conda
-  sha256: 49ee6fcb59e63cceb1f01777ac8b67d44633b6cdad5c47b02bc995f6e96955eb
-  md5: 0a28337559bbd97ff6d99598c7a3ffb4
-  depends:
-  - __osx >=11.0
-  - idna >=2.0
-  - multidict >=4.0
-  - propcache >=0.2.1
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/yarl?source=hash-mapping
-  size: 144046
-  timestamp: 1761337516302
-- conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.22.0-py312h05f76fc_0.conda
-  sha256: b622ef03b033a1c3984cb3e47e198370f23bf239c579a0c04f9179237fbb541b
-  md5: d4975947624e265fa594b86ce148a0c1
-  depends:
-  - idna >=2.0
-  - multidict >=4.0
-  - propcache >=0.2.1
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/yarl?source=hash-mapping
-  size: 141998
-  timestamp: 1761337573480
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
-  sha256: c2bcb8aa930d6ea3c9c7a64fc4fab58ad7bcac483a9a45de294f67d2f447f413
-  md5: 02738ff9855946075cbd1b5274399a41
-  depends:
-  - python
-  - cffi >=1.11
-  - zstd >=1.5.7,<1.5.8.0a0
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - zstd >=1.5.7,<1.6.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  purls:
-  - pkg:pypi/zstandard?source=compressed-mapping
-  size: 467133
-  timestamp: 1762512686069
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py312h37e1c23_1.conda
-  sha256: af843b0fe62d128a70f91dc954b2cb692f349a237b461788bd25dd928d0d1ef8
-  md5: 9300889791d4decceea3728ad3b423ec
-  depends:
-  - python
-  - cffi >=1.11
-  - zstd >=1.5.7,<1.5.8.0a0
-  - python 3.12.* *_cpython
-  - __osx >=11.0
-  - python_abi 3.12.* *_cp312
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  purls:
-  - pkg:pypi/zstandard?source=hash-mapping
-  size: 390920
-  timestamp: 1762512713481
-- conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py312he5662c2_1.conda
-  sha256: 49241574c373331ae63d9cb4978836db3b2571176a7db81fe48436c84ce38ff4
-  md5: e9e25949b682e95535068bae33153ba6
-  depends:
-  - python
-  - cffi >=1.11
-  - zstd >=1.5.7,<1.5.8.0a0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - zstd >=1.5.7,<1.6.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  purls:
-  - pkg:pypi/zstandard?source=hash-mapping
-  size: 374949
-  timestamp: 1762512770373
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-  sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
-  md5: 6432cb5d4ac0046c3ac0a8a0f95842f9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 567578
-  timestamp: 1742433379869
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
-  sha256: 0d02046f57f7a1a3feae3e9d1aa2113788311f3cf37a3244c71e61a93177ba67
-  md5: e6f69c7bcccdefa417f056fa593b40f0
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 399979
-  timestamp: 1742433432699
-- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
-  sha256: bc64864377d809b904e877a98d0584f43836c9f2ef27d3d2a1421fa6eae7ca04
-  md5: 21f56217d6125fb30c3c3f10c786d751
-  depends:
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 354697
-  timestamp: 1742433568506
+- pypi: https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl
+  name: py-partiql-parser
+  version: 0.6.3
+  sha256: deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582
+  requires_dist:
+  - black==22.6.0 ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - mypy ; extra == 'dev'
+  - pytest ; extra == 'dev'
+- pypi: https://files.pythonhosted.org/packages/d6/a8/fb90c26333cd9362dfb49c03a3e6382ebf493dc46d299e72fd5a85dec1e9/conda_forge_metadata-0.12.0-py3-none-any.whl
+  name: conda-forge-metadata
+  version: 0.12.0
+  sha256: ad727a92efbe41caf32412d0c4dcfd54da4f4a8b0ce8b55d5455a5f4631e542b
+  requires_dist:
+  - deprecated
+  - requests
+  - ruamel-yaml
+  - typing-extensions
+  - beautifulsoup4
+  - conda-oci-mirror
+  - conda-package-streaming>=0.12.0
+  - conda-oci-mirror ; extra == 'oci'
+- pypi: https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl
+  name: types-aioboto3
+  version: 15.5.0
+  sha256: 8aed7c9b6fe9b59e6ce74f7a6db7b8a9912a34c8f80ed639fac1fa59d6b20aa1
+  requires_dist:
+  - botocore-stubs
+  - types-aiobotocore
+  - types-s3transfer
+  - typing-extensions>=4.1.0 ; python_full_version < '3.12'
+  - types-aiobotocore-full>=2.25.0,<2.26.0 ; extra == 'full'
+  - aioboto3==15.5.0 ; extra == 'aioboto3'
+  - types-aiobotocore-accessanalyzer>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-account>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-acm>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-acm-pca>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-aiops>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-amp>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-amplify>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-amplifybackend>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-amplifyuibuilder>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-apigateway>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-apigatewaymanagementapi>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-apigatewayv2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-appconfig>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-appconfigdata>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-appfabric>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-appflow>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-appintegrations>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-application-autoscaling>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-application-insights>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-application-signals>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-applicationcostprofiler>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-appmesh>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-apprunner>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-appstream>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-appsync>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-arc-region-switch>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-arc-zonal-shift>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-artifact>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-athena>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-auditmanager>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-autoscaling>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-autoscaling-plans>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-b2bi>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-backup>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-backup-gateway>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-backupsearch>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-batch>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bcm-dashboards>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bcm-data-exports>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bcm-pricing-calculator>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bcm-recommended-actions>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bedrock>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bedrock-agent>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bedrock-agent-runtime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bedrock-agentcore>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bedrock-agentcore-control>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bedrock-data-automation>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bedrock-data-automation-runtime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-bedrock-runtime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-billing>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-billingconductor>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-braket>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-budgets>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ce>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-chatbot>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-chime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-chime-sdk-identity>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-chime-sdk-media-pipelines>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-chime-sdk-meetings>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-chime-sdk-messaging>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-chime-sdk-voice>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cleanrooms>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cleanroomsml>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloud9>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudcontrol>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-clouddirectory>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudformation>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudfront>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudfront-keyvaluestore>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudhsm>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudhsmv2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudsearch>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudsearchdomain>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudtrail>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudtrail-data>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudwatch>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codeartifact>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codebuild>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codecatalyst>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codecommit>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codeconnections>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codedeploy>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codeguru-reviewer>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codeguru-security>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codeguruprofiler>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codepipeline>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codestar-connections>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-codestar-notifications>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cognito-identity>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cognito-idp>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cognito-sync>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-comprehend>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-comprehendmedical>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-compute-optimizer>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-config>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-connect>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-connect-contact-lens>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-connectcampaigns>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-connectcampaignsv2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-connectcases>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-connectparticipant>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-controlcatalog>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-controltower>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cost-optimization-hub>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cur>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-customer-profiles>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-databrew>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-dataexchange>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-datapipeline>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-datasync>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-datazone>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-dax>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-deadline>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-detective>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-devicefarm>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-devops-guru>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-directconnect>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-discovery>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-dlm>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-dms>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-docdb>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-docdb-elastic>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-drs>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ds>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ds-data>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-dsql>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-dynamodb>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-dynamodbstreams>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ebs>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ec2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ec2-instance-connect>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ecr>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ecr-public>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ecs>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-efs>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-eks>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-eks-auth>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-elasticache>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-elasticbeanstalk>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-elastictranscoder>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-elb>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-elbv2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-emr>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-emr-containers>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-emr-serverless>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-entityresolution>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-es>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-events>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-evidently>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-evs>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-finspace>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-finspace-data>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-firehose>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-fis>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-fms>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-forecast>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-forecastquery>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-frauddetector>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-freetier>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-fsx>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-gamelift>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-gameliftstreams>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-geo-maps>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-geo-places>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-geo-routes>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-glacier>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-globalaccelerator>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-glue>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-grafana>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-greengrass>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-greengrassv2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-groundstation>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-guardduty>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-health>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-healthlake>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iam>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-identitystore>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-imagebuilder>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-importexport>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-inspector>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-inspector-scan>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-inspector2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-internetmonitor>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-invoicing>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iot>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iot-data>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iot-jobs-data>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iot-managed-integrations>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iotanalytics>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iotdeviceadvisor>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iotevents>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iotevents-data>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iotfleetwise>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iotsecuretunneling>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iotsitewise>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iotthingsgraph>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iottwinmaker>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-iotwireless>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ivs>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ivs-realtime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ivschat>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kafka>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kafkaconnect>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kendra>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kendra-ranking>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-keyspaces>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-keyspacesstreams>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kinesis>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kinesis-video-archived-media>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kinesis-video-media>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kinesis-video-signaling>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kinesis-video-webrtc-storage>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kinesisanalytics>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kinesisanalyticsv2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kinesisvideo>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-kms>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-lakeformation>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-lambda>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-launch-wizard>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-lex-models>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-lex-runtime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-lexv2-models>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-lexv2-runtime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-license-manager>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-license-manager-linux-subscriptions>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-license-manager-user-subscriptions>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-lightsail>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-location>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-logs>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-lookoutequipment>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-m2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-machinelearning>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-macie2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mailmanager>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-managedblockchain>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-managedblockchain-query>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-marketplace-agreement>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-marketplace-catalog>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-marketplace-deployment>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-marketplace-entitlement>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-marketplace-reporting>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-marketplacecommerceanalytics>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mediaconnect>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mediaconvert>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-medialive>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mediapackage>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mediapackage-vod>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mediapackagev2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mediastore>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mediastore-data>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mediatailor>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-medical-imaging>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-memorydb>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-meteringmarketplace>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mgh>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mgn>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-migration-hub-refactor-spaces>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-migrationhub-config>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-migrationhuborchestrator>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-migrationhubstrategy>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mpa>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mq>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mturk>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-mwaa>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-neptune>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-neptune-graph>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-neptunedata>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-network-firewall>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-networkflowmonitor>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-networkmanager>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-networkmonitor>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-notifications>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-notificationscontacts>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-oam>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-observabilityadmin>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-odb>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-omics>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-opensearch>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-opensearchserverless>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-organizations>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-osis>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-outposts>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-panorama>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-partnercentral-selling>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-payment-cryptography>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-payment-cryptography-data>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-pca-connector-ad>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-pca-connector-scep>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-pcs>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-personalize>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-personalize-events>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-personalize-runtime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-pi>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-pinpoint>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-pinpoint-email>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-pinpoint-sms-voice>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-pinpoint-sms-voice-v2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-pipes>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-polly>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-pricing>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-proton>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-qapps>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-qbusiness>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-qconnect>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-quicksight>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ram>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-rbin>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-rds>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-rds-data>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-redshift>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-redshift-data>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-redshift-serverless>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-rekognition>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-repostspace>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-resiliencehub>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-resource-explorer-2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-resource-groups>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-resourcegroupstaggingapi>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-rolesanywhere>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-route53>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-route53-recovery-cluster>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-route53-recovery-control-config>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-route53-recovery-readiness>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-route53domains>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-route53profiles>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-route53resolver>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-rtbfabric>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-rum>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-s3>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-s3control>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-s3outposts>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-s3tables>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-s3vectors>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sagemaker>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sagemaker-a2i-runtime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sagemaker-edge>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sagemaker-featurestore-runtime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sagemaker-geospatial>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sagemaker-metrics>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sagemaker-runtime>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-savingsplans>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-scheduler>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-schemas>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sdb>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-secretsmanager>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-security-ir>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-securityhub>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-securitylake>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-serverlessrepo>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-service-quotas>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-servicecatalog>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-servicecatalog-appregistry>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-servicediscovery>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ses>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sesv2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-shield>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-signer>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-simspaceweaver>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-snow-device-management>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-snowball>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sns>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-socialmessaging>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sqs>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ssm>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ssm-contacts>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ssm-guiconnect>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ssm-incidents>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ssm-quicksetup>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-ssm-sap>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sso>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sso-admin>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sso-oidc>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-stepfunctions>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-storagegateway>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-sts>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-supplychain>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-support>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-support-app>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-swf>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-synthetics>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-taxsettings>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-textract>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-timestream-influxdb>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-timestream-query>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-timestream-write>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-tnb>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-transcribe>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-transfer>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-translate>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-trustedadvisor>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-verifiedpermissions>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-voice-id>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-vpc-lattice>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-waf>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-waf-regional>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-wafv2>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-wellarchitected>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-wisdom>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-workdocs>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-workmail>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-workmailmessageflow>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-workspaces>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-workspaces-instances>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-workspaces-thin-client>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-workspaces-web>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-xray>=2.25.0,<2.26.0 ; extra == 'all'
+  - types-aiobotocore-cloudformation>=2.25.0,<2.26.0 ; extra == 'essential'
+  - types-aiobotocore-dynamodb>=2.25.0,<2.26.0 ; extra == 'essential'
+  - types-aiobotocore-ec2>=2.25.0,<2.26.0 ; extra == 'essential'
+  - types-aiobotocore-lambda>=2.25.0,<2.26.0 ; extra == 'essential'
+  - types-aiobotocore-rds>=2.25.0,<2.26.0 ; extra == 'essential'
+  - types-aiobotocore-s3>=2.25.0,<2.26.0 ; extra == 'essential'
+  - types-aiobotocore-sqs>=2.25.0,<2.26.0 ; extra == 'essential'
+  - types-aiobotocore-accessanalyzer>=2.25.0,<2.26.0 ; extra == 'accessanalyzer'
+  - types-aiobotocore-account>=2.25.0,<2.26.0 ; extra == 'account'
+  - types-aiobotocore-acm>=2.25.0,<2.26.0 ; extra == 'acm'
+  - types-aiobotocore-acm-pca>=2.25.0,<2.26.0 ; extra == 'acm-pca'
+  - types-aiobotocore-aiops>=2.25.0,<2.26.0 ; extra == 'aiops'
+  - types-aiobotocore-amp>=2.25.0,<2.26.0 ; extra == 'amp'
+  - types-aiobotocore-amplify>=2.25.0,<2.26.0 ; extra == 'amplify'
+  - types-aiobotocore-amplifybackend>=2.25.0,<2.26.0 ; extra == 'amplifybackend'
+  - types-aiobotocore-amplifyuibuilder>=2.25.0,<2.26.0 ; extra == 'amplifyuibuilder'
+  - types-aiobotocore-apigateway>=2.25.0,<2.26.0 ; extra == 'apigateway'
+  - types-aiobotocore-apigatewaymanagementapi>=2.25.0,<2.26.0 ; extra == 'apigatewaymanagementapi'
+  - types-aiobotocore-apigatewayv2>=2.25.0,<2.26.0 ; extra == 'apigatewayv2'
+  - types-aiobotocore-appconfig>=2.25.0,<2.26.0 ; extra == 'appconfig'
+  - types-aiobotocore-appconfigdata>=2.25.0,<2.26.0 ; extra == 'appconfigdata'
+  - types-aiobotocore-appfabric>=2.25.0,<2.26.0 ; extra == 'appfabric'
+  - types-aiobotocore-appflow>=2.25.0,<2.26.0 ; extra == 'appflow'
+  - types-aiobotocore-appintegrations>=2.25.0,<2.26.0 ; extra == 'appintegrations'
+  - types-aiobotocore-application-autoscaling>=2.25.0,<2.26.0 ; extra == 'application-autoscaling'
+  - types-aiobotocore-application-insights>=2.25.0,<2.26.0 ; extra == 'application-insights'
+  - types-aiobotocore-application-signals>=2.25.0,<2.26.0 ; extra == 'application-signals'
+  - types-aiobotocore-applicationcostprofiler>=2.25.0,<2.26.0 ; extra == 'applicationcostprofiler'
+  - types-aiobotocore-appmesh>=2.25.0,<2.26.0 ; extra == 'appmesh'
+  - types-aiobotocore-apprunner>=2.25.0,<2.26.0 ; extra == 'apprunner'
+  - types-aiobotocore-appstream>=2.25.0,<2.26.0 ; extra == 'appstream'
+  - types-aiobotocore-appsync>=2.25.0,<2.26.0 ; extra == 'appsync'
+  - types-aiobotocore-arc-region-switch>=2.25.0,<2.26.0 ; extra == 'arc-region-switch'
+  - types-aiobotocore-arc-zonal-shift>=2.25.0,<2.26.0 ; extra == 'arc-zonal-shift'
+  - types-aiobotocore-artifact>=2.25.0,<2.26.0 ; extra == 'artifact'
+  - types-aiobotocore-athena>=2.25.0,<2.26.0 ; extra == 'athena'
+  - types-aiobotocore-auditmanager>=2.25.0,<2.26.0 ; extra == 'auditmanager'
+  - types-aiobotocore-autoscaling>=2.25.0,<2.26.0 ; extra == 'autoscaling'
+  - types-aiobotocore-autoscaling-plans>=2.25.0,<2.26.0 ; extra == 'autoscaling-plans'
+  - types-aiobotocore-b2bi>=2.25.0,<2.26.0 ; extra == 'b2bi'
+  - types-aiobotocore-backup>=2.25.0,<2.26.0 ; extra == 'backup'
+  - types-aiobotocore-backup-gateway>=2.25.0,<2.26.0 ; extra == 'backup-gateway'
+  - types-aiobotocore-backupsearch>=2.25.0,<2.26.0 ; extra == 'backupsearch'
+  - types-aiobotocore-batch>=2.25.0,<2.26.0 ; extra == 'batch'
+  - types-aiobotocore-bcm-dashboards>=2.25.0,<2.26.0 ; extra == 'bcm-dashboards'
+  - types-aiobotocore-bcm-data-exports>=2.25.0,<2.26.0 ; extra == 'bcm-data-exports'
+  - types-aiobotocore-bcm-pricing-calculator>=2.25.0,<2.26.0 ; extra == 'bcm-pricing-calculator'
+  - types-aiobotocore-bcm-recommended-actions>=2.25.0,<2.26.0 ; extra == 'bcm-recommended-actions'
+  - types-aiobotocore-bedrock>=2.25.0,<2.26.0 ; extra == 'bedrock'
+  - types-aiobotocore-bedrock-agent>=2.25.0,<2.26.0 ; extra == 'bedrock-agent'
+  - types-aiobotocore-bedrock-agent-runtime>=2.25.0,<2.26.0 ; extra == 'bedrock-agent-runtime'
+  - types-aiobotocore-bedrock-agentcore>=2.25.0,<2.26.0 ; extra == 'bedrock-agentcore'
+  - types-aiobotocore-bedrock-agentcore-control>=2.25.0,<2.26.0 ; extra == 'bedrock-agentcore-control'
+  - types-aiobotocore-bedrock-data-automation>=2.25.0,<2.26.0 ; extra == 'bedrock-data-automation'
+  - types-aiobotocore-bedrock-data-automation-runtime>=2.25.0,<2.26.0 ; extra == 'bedrock-data-automation-runtime'
+  - types-aiobotocore-bedrock-runtime>=2.25.0,<2.26.0 ; extra == 'bedrock-runtime'
+  - types-aiobotocore-billing>=2.25.0,<2.26.0 ; extra == 'billing'
+  - types-aiobotocore-billingconductor>=2.25.0,<2.26.0 ; extra == 'billingconductor'
+  - types-aiobotocore-braket>=2.25.0,<2.26.0 ; extra == 'braket'
+  - types-aiobotocore-budgets>=2.25.0,<2.26.0 ; extra == 'budgets'
+  - types-aiobotocore-ce>=2.25.0,<2.26.0 ; extra == 'ce'
+  - types-aiobotocore-chatbot>=2.25.0,<2.26.0 ; extra == 'chatbot'
+  - types-aiobotocore-chime>=2.25.0,<2.26.0 ; extra == 'chime'
+  - types-aiobotocore-chime-sdk-identity>=2.25.0,<2.26.0 ; extra == 'chime-sdk-identity'
+  - types-aiobotocore-chime-sdk-media-pipelines>=2.25.0,<2.26.0 ; extra == 'chime-sdk-media-pipelines'
+  - types-aiobotocore-chime-sdk-meetings>=2.25.0,<2.26.0 ; extra == 'chime-sdk-meetings'
+  - types-aiobotocore-chime-sdk-messaging>=2.25.0,<2.26.0 ; extra == 'chime-sdk-messaging'
+  - types-aiobotocore-chime-sdk-voice>=2.25.0,<2.26.0 ; extra == 'chime-sdk-voice'
+  - types-aiobotocore-cleanrooms>=2.25.0,<2.26.0 ; extra == 'cleanrooms'
+  - types-aiobotocore-cleanroomsml>=2.25.0,<2.26.0 ; extra == 'cleanroomsml'
+  - types-aiobotocore-cloud9>=2.25.0,<2.26.0 ; extra == 'cloud9'
+  - types-aiobotocore-cloudcontrol>=2.25.0,<2.26.0 ; extra == 'cloudcontrol'
+  - types-aiobotocore-clouddirectory>=2.25.0,<2.26.0 ; extra == 'clouddirectory'
+  - types-aiobotocore-cloudformation>=2.25.0,<2.26.0 ; extra == 'cloudformation'
+  - types-aiobotocore-cloudfront>=2.25.0,<2.26.0 ; extra == 'cloudfront'
+  - types-aiobotocore-cloudfront-keyvaluestore>=2.25.0,<2.26.0 ; extra == 'cloudfront-keyvaluestore'
+  - types-aiobotocore-cloudhsm>=2.25.0,<2.26.0 ; extra == 'cloudhsm'
+  - types-aiobotocore-cloudhsmv2>=2.25.0,<2.26.0 ; extra == 'cloudhsmv2'
+  - types-aiobotocore-cloudsearch>=2.25.0,<2.26.0 ; extra == 'cloudsearch'
+  - types-aiobotocore-cloudsearchdomain>=2.25.0,<2.26.0 ; extra == 'cloudsearchdomain'
+  - types-aiobotocore-cloudtrail>=2.25.0,<2.26.0 ; extra == 'cloudtrail'
+  - types-aiobotocore-cloudtrail-data>=2.25.0,<2.26.0 ; extra == 'cloudtrail-data'
+  - types-aiobotocore-cloudwatch>=2.25.0,<2.26.0 ; extra == 'cloudwatch'
+  - types-aiobotocore-codeartifact>=2.25.0,<2.26.0 ; extra == 'codeartifact'
+  - types-aiobotocore-codebuild>=2.25.0,<2.26.0 ; extra == 'codebuild'
+  - types-aiobotocore-codecatalyst>=2.25.0,<2.26.0 ; extra == 'codecatalyst'
+  - types-aiobotocore-codecommit>=2.25.0,<2.26.0 ; extra == 'codecommit'
+  - types-aiobotocore-codeconnections>=2.25.0,<2.26.0 ; extra == 'codeconnections'
+  - types-aiobotocore-codedeploy>=2.25.0,<2.26.0 ; extra == 'codedeploy'
+  - types-aiobotocore-codeguru-reviewer>=2.25.0,<2.26.0 ; extra == 'codeguru-reviewer'
+  - types-aiobotocore-codeguru-security>=2.25.0,<2.26.0 ; extra == 'codeguru-security'
+  - types-aiobotocore-codeguruprofiler>=2.25.0,<2.26.0 ; extra == 'codeguruprofiler'
+  - types-aiobotocore-codepipeline>=2.25.0,<2.26.0 ; extra == 'codepipeline'
+  - types-aiobotocore-codestar-connections>=2.25.0,<2.26.0 ; extra == 'codestar-connections'
+  - types-aiobotocore-codestar-notifications>=2.25.0,<2.26.0 ; extra == 'codestar-notifications'
+  - types-aiobotocore-cognito-identity>=2.25.0,<2.26.0 ; extra == 'cognito-identity'
+  - types-aiobotocore-cognito-idp>=2.25.0,<2.26.0 ; extra == 'cognito-idp'
+  - types-aiobotocore-cognito-sync>=2.25.0,<2.26.0 ; extra == 'cognito-sync'
+  - types-aiobotocore-comprehend>=2.25.0,<2.26.0 ; extra == 'comprehend'
+  - types-aiobotocore-comprehendmedical>=2.25.0,<2.26.0 ; extra == 'comprehendmedical'
+  - types-aiobotocore-compute-optimizer>=2.25.0,<2.26.0 ; extra == 'compute-optimizer'
+  - types-aiobotocore-config>=2.25.0,<2.26.0 ; extra == 'config'
+  - types-aiobotocore-connect>=2.25.0,<2.26.0 ; extra == 'connect'
+  - types-aiobotocore-connect-contact-lens>=2.25.0,<2.26.0 ; extra == 'connect-contact-lens'
+  - types-aiobotocore-connectcampaigns>=2.25.0,<2.26.0 ; extra == 'connectcampaigns'
+  - types-aiobotocore-connectcampaignsv2>=2.25.0,<2.26.0 ; extra == 'connectcampaignsv2'
+  - types-aiobotocore-connectcases>=2.25.0,<2.26.0 ; extra == 'connectcases'
+  - types-aiobotocore-connectparticipant>=2.25.0,<2.26.0 ; extra == 'connectparticipant'
+  - types-aiobotocore-controlcatalog>=2.25.0,<2.26.0 ; extra == 'controlcatalog'
+  - types-aiobotocore-controltower>=2.25.0,<2.26.0 ; extra == 'controltower'
+  - types-aiobotocore-cost-optimization-hub>=2.25.0,<2.26.0 ; extra == 'cost-optimization-hub'
+  - types-aiobotocore-cur>=2.25.0,<2.26.0 ; extra == 'cur'
+  - types-aiobotocore-customer-profiles>=2.25.0,<2.26.0 ; extra == 'customer-profiles'
+  - types-aiobotocore-databrew>=2.25.0,<2.26.0 ; extra == 'databrew'
+  - types-aiobotocore-dataexchange>=2.25.0,<2.26.0 ; extra == 'dataexchange'
+  - types-aiobotocore-datapipeline>=2.25.0,<2.26.0 ; extra == 'datapipeline'
+  - types-aiobotocore-datasync>=2.25.0,<2.26.0 ; extra == 'datasync'
+  - types-aiobotocore-datazone>=2.25.0,<2.26.0 ; extra == 'datazone'
+  - types-aiobotocore-dax>=2.25.0,<2.26.0 ; extra == 'dax'
+  - types-aiobotocore-deadline>=2.25.0,<2.26.0 ; extra == 'deadline'
+  - types-aiobotocore-detective>=2.25.0,<2.26.0 ; extra == 'detective'
+  - types-aiobotocore-devicefarm>=2.25.0,<2.26.0 ; extra == 'devicefarm'
+  - types-aiobotocore-devops-guru>=2.25.0,<2.26.0 ; extra == 'devops-guru'
+  - types-aiobotocore-directconnect>=2.25.0,<2.26.0 ; extra == 'directconnect'
+  - types-aiobotocore-discovery>=2.25.0,<2.26.0 ; extra == 'discovery'
+  - types-aiobotocore-dlm>=2.25.0,<2.26.0 ; extra == 'dlm'
+  - types-aiobotocore-dms>=2.25.0,<2.26.0 ; extra == 'dms'
+  - types-aiobotocore-docdb>=2.25.0,<2.26.0 ; extra == 'docdb'
+  - types-aiobotocore-docdb-elastic>=2.25.0,<2.26.0 ; extra == 'docdb-elastic'
+  - types-aiobotocore-drs>=2.25.0,<2.26.0 ; extra == 'drs'
+  - types-aiobotocore-ds>=2.25.0,<2.26.0 ; extra == 'ds'
+  - types-aiobotocore-ds-data>=2.25.0,<2.26.0 ; extra == 'ds-data'
+  - types-aiobotocore-dsql>=2.25.0,<2.26.0 ; extra == 'dsql'
+  - types-aiobotocore-dynamodb>=2.25.0,<2.26.0 ; extra == 'dynamodb'
+  - types-aiobotocore-dynamodbstreams>=2.25.0,<2.26.0 ; extra == 'dynamodbstreams'
+  - types-aiobotocore-ebs>=2.25.0,<2.26.0 ; extra == 'ebs'
+  - types-aiobotocore-ec2>=2.25.0,<2.26.0 ; extra == 'ec2'
+  - types-aiobotocore-ec2-instance-connect>=2.25.0,<2.26.0 ; extra == 'ec2-instance-connect'
+  - types-aiobotocore-ecr>=2.25.0,<2.26.0 ; extra == 'ecr'
+  - types-aiobotocore-ecr-public>=2.25.0,<2.26.0 ; extra == 'ecr-public'
+  - types-aiobotocore-ecs>=2.25.0,<2.26.0 ; extra == 'ecs'
+  - types-aiobotocore-efs>=2.25.0,<2.26.0 ; extra == 'efs'
+  - types-aiobotocore-eks>=2.25.0,<2.26.0 ; extra == 'eks'
+  - types-aiobotocore-eks-auth>=2.25.0,<2.26.0 ; extra == 'eks-auth'
+  - types-aiobotocore-elasticache>=2.25.0,<2.26.0 ; extra == 'elasticache'
+  - types-aiobotocore-elasticbeanstalk>=2.25.0,<2.26.0 ; extra == 'elasticbeanstalk'
+  - types-aiobotocore-elastictranscoder>=2.25.0,<2.26.0 ; extra == 'elastictranscoder'
+  - types-aiobotocore-elb>=2.25.0,<2.26.0 ; extra == 'elb'
+  - types-aiobotocore-elbv2>=2.25.0,<2.26.0 ; extra == 'elbv2'
+  - types-aiobotocore-emr>=2.25.0,<2.26.0 ; extra == 'emr'
+  - types-aiobotocore-emr-containers>=2.25.0,<2.26.0 ; extra == 'emr-containers'
+  - types-aiobotocore-emr-serverless>=2.25.0,<2.26.0 ; extra == 'emr-serverless'
+  - types-aiobotocore-entityresolution>=2.25.0,<2.26.0 ; extra == 'entityresolution'
+  - types-aiobotocore-es>=2.25.0,<2.26.0 ; extra == 'es'
+  - types-aiobotocore-events>=2.25.0,<2.26.0 ; extra == 'events'
+  - types-aiobotocore-evidently>=2.25.0,<2.26.0 ; extra == 'evidently'
+  - types-aiobotocore-evs>=2.25.0,<2.26.0 ; extra == 'evs'
+  - types-aiobotocore-finspace>=2.25.0,<2.26.0 ; extra == 'finspace'
+  - types-aiobotocore-finspace-data>=2.25.0,<2.26.0 ; extra == 'finspace-data'
+  - types-aiobotocore-firehose>=2.25.0,<2.26.0 ; extra == 'firehose'
+  - types-aiobotocore-fis>=2.25.0,<2.26.0 ; extra == 'fis'
+  - types-aiobotocore-fms>=2.25.0,<2.26.0 ; extra == 'fms'
+  - types-aiobotocore-forecast>=2.25.0,<2.26.0 ; extra == 'forecast'
+  - types-aiobotocore-forecastquery>=2.25.0,<2.26.0 ; extra == 'forecastquery'
+  - types-aiobotocore-frauddetector>=2.25.0,<2.26.0 ; extra == 'frauddetector'
+  - types-aiobotocore-freetier>=2.25.0,<2.26.0 ; extra == 'freetier'
+  - types-aiobotocore-fsx>=2.25.0,<2.26.0 ; extra == 'fsx'
+  - types-aiobotocore-gamelift>=2.25.0,<2.26.0 ; extra == 'gamelift'
+  - types-aiobotocore-gameliftstreams>=2.25.0,<2.26.0 ; extra == 'gameliftstreams'
+  - types-aiobotocore-geo-maps>=2.25.0,<2.26.0 ; extra == 'geo-maps'
+  - types-aiobotocore-geo-places>=2.25.0,<2.26.0 ; extra == 'geo-places'
+  - types-aiobotocore-geo-routes>=2.25.0,<2.26.0 ; extra == 'geo-routes'
+  - types-aiobotocore-glacier>=2.25.0,<2.26.0 ; extra == 'glacier'
+  - types-aiobotocore-globalaccelerator>=2.25.0,<2.26.0 ; extra == 'globalaccelerator'
+  - types-aiobotocore-glue>=2.25.0,<2.26.0 ; extra == 'glue'
+  - types-aiobotocore-grafana>=2.25.0,<2.26.0 ; extra == 'grafana'
+  - types-aiobotocore-greengrass>=2.25.0,<2.26.0 ; extra == 'greengrass'
+  - types-aiobotocore-greengrassv2>=2.25.0,<2.26.0 ; extra == 'greengrassv2'
+  - types-aiobotocore-groundstation>=2.25.0,<2.26.0 ; extra == 'groundstation'
+  - types-aiobotocore-guardduty>=2.25.0,<2.26.0 ; extra == 'guardduty'
+  - types-aiobotocore-health>=2.25.0,<2.26.0 ; extra == 'health'
+  - types-aiobotocore-healthlake>=2.25.0,<2.26.0 ; extra == 'healthlake'
+  - types-aiobotocore-iam>=2.25.0,<2.26.0 ; extra == 'iam'
+  - types-aiobotocore-identitystore>=2.25.0,<2.26.0 ; extra == 'identitystore'
+  - types-aiobotocore-imagebuilder>=2.25.0,<2.26.0 ; extra == 'imagebuilder'
+  - types-aiobotocore-importexport>=2.25.0,<2.26.0 ; extra == 'importexport'
+  - types-aiobotocore-inspector>=2.25.0,<2.26.0 ; extra == 'inspector'
+  - types-aiobotocore-inspector-scan>=2.25.0,<2.26.0 ; extra == 'inspector-scan'
+  - types-aiobotocore-inspector2>=2.25.0,<2.26.0 ; extra == 'inspector2'
+  - types-aiobotocore-internetmonitor>=2.25.0,<2.26.0 ; extra == 'internetmonitor'
+  - types-aiobotocore-invoicing>=2.25.0,<2.26.0 ; extra == 'invoicing'
+  - types-aiobotocore-iot>=2.25.0,<2.26.0 ; extra == 'iot'
+  - types-aiobotocore-iot-data>=2.25.0,<2.26.0 ; extra == 'iot-data'
+  - types-aiobotocore-iot-jobs-data>=2.25.0,<2.26.0 ; extra == 'iot-jobs-data'
+  - types-aiobotocore-iot-managed-integrations>=2.25.0,<2.26.0 ; extra == 'iot-managed-integrations'
+  - types-aiobotocore-iotanalytics>=2.25.0,<2.26.0 ; extra == 'iotanalytics'
+  - types-aiobotocore-iotdeviceadvisor>=2.25.0,<2.26.0 ; extra == 'iotdeviceadvisor'
+  - types-aiobotocore-iotevents>=2.25.0,<2.26.0 ; extra == 'iotevents'
+  - types-aiobotocore-iotevents-data>=2.25.0,<2.26.0 ; extra == 'iotevents-data'
+  - types-aiobotocore-iotfleetwise>=2.25.0,<2.26.0 ; extra == 'iotfleetwise'
+  - types-aiobotocore-iotsecuretunneling>=2.25.0,<2.26.0 ; extra == 'iotsecuretunneling'
+  - types-aiobotocore-iotsitewise>=2.25.0,<2.26.0 ; extra == 'iotsitewise'
+  - types-aiobotocore-iotthingsgraph>=2.25.0,<2.26.0 ; extra == 'iotthingsgraph'
+  - types-aiobotocore-iottwinmaker>=2.25.0,<2.26.0 ; extra == 'iottwinmaker'
+  - types-aiobotocore-iotwireless>=2.25.0,<2.26.0 ; extra == 'iotwireless'
+  - types-aiobotocore-ivs>=2.25.0,<2.26.0 ; extra == 'ivs'
+  - types-aiobotocore-ivs-realtime>=2.25.0,<2.26.0 ; extra == 'ivs-realtime'
+  - types-aiobotocore-ivschat>=2.25.0,<2.26.0 ; extra == 'ivschat'
+  - types-aiobotocore-kafka>=2.25.0,<2.26.0 ; extra == 'kafka'
+  - types-aiobotocore-kafkaconnect>=2.25.0,<2.26.0 ; extra == 'kafkaconnect'
+  - types-aiobotocore-kendra>=2.25.0,<2.26.0 ; extra == 'kendra'
+  - types-aiobotocore-kendra-ranking>=2.25.0,<2.26.0 ; extra == 'kendra-ranking'
+  - types-aiobotocore-keyspaces>=2.25.0,<2.26.0 ; extra == 'keyspaces'
+  - types-aiobotocore-keyspacesstreams>=2.25.0,<2.26.0 ; extra == 'keyspacesstreams'
+  - types-aiobotocore-kinesis>=2.25.0,<2.26.0 ; extra == 'kinesis'
+  - types-aiobotocore-kinesis-video-archived-media>=2.25.0,<2.26.0 ; extra == 'kinesis-video-archived-media'
+  - types-aiobotocore-kinesis-video-media>=2.25.0,<2.26.0 ; extra == 'kinesis-video-media'
+  - types-aiobotocore-kinesis-video-signaling>=2.25.0,<2.26.0 ; extra == 'kinesis-video-signaling'
+  - types-aiobotocore-kinesis-video-webrtc-storage>=2.25.0,<2.26.0 ; extra == 'kinesis-video-webrtc-storage'
+  - types-aiobotocore-kinesisanalytics>=2.25.0,<2.26.0 ; extra == 'kinesisanalytics'
+  - types-aiobotocore-kinesisanalyticsv2>=2.25.0,<2.26.0 ; extra == 'kinesisanalyticsv2'
+  - types-aiobotocore-kinesisvideo>=2.25.0,<2.26.0 ; extra == 'kinesisvideo'
+  - types-aiobotocore-kms>=2.25.0,<2.26.0 ; extra == 'kms'
+  - types-aiobotocore-lakeformation>=2.25.0,<2.26.0 ; extra == 'lakeformation'
+  - types-aiobotocore-lambda>=2.25.0,<2.26.0 ; extra == 'lambda'
+  - types-aiobotocore-launch-wizard>=2.25.0,<2.26.0 ; extra == 'launch-wizard'
+  - types-aiobotocore-lex-models>=2.25.0,<2.26.0 ; extra == 'lex-models'
+  - types-aiobotocore-lex-runtime>=2.25.0,<2.26.0 ; extra == 'lex-runtime'
+  - types-aiobotocore-lexv2-models>=2.25.0,<2.26.0 ; extra == 'lexv2-models'
+  - types-aiobotocore-lexv2-runtime>=2.25.0,<2.26.0 ; extra == 'lexv2-runtime'
+  - types-aiobotocore-license-manager>=2.25.0,<2.26.0 ; extra == 'license-manager'
+  - types-aiobotocore-license-manager-linux-subscriptions>=2.25.0,<2.26.0 ; extra == 'license-manager-linux-subscriptions'
+  - types-aiobotocore-license-manager-user-subscriptions>=2.25.0,<2.26.0 ; extra == 'license-manager-user-subscriptions'
+  - types-aiobotocore-lightsail>=2.25.0,<2.26.0 ; extra == 'lightsail'
+  - types-aiobotocore-location>=2.25.0,<2.26.0 ; extra == 'location'
+  - types-aiobotocore-logs>=2.25.0,<2.26.0 ; extra == 'logs'
+  - types-aiobotocore-lookoutequipment>=2.25.0,<2.26.0 ; extra == 'lookoutequipment'
+  - types-aiobotocore-m2>=2.25.0,<2.26.0 ; extra == 'm2'
+  - types-aiobotocore-machinelearning>=2.25.0,<2.26.0 ; extra == 'machinelearning'
+  - types-aiobotocore-macie2>=2.25.0,<2.26.0 ; extra == 'macie2'
+  - types-aiobotocore-mailmanager>=2.25.0,<2.26.0 ; extra == 'mailmanager'
+  - types-aiobotocore-managedblockchain>=2.25.0,<2.26.0 ; extra == 'managedblockchain'
+  - types-aiobotocore-managedblockchain-query>=2.25.0,<2.26.0 ; extra == 'managedblockchain-query'
+  - types-aiobotocore-marketplace-agreement>=2.25.0,<2.26.0 ; extra == 'marketplace-agreement'
+  - types-aiobotocore-marketplace-catalog>=2.25.0,<2.26.0 ; extra == 'marketplace-catalog'
+  - types-aiobotocore-marketplace-deployment>=2.25.0,<2.26.0 ; extra == 'marketplace-deployment'
+  - types-aiobotocore-marketplace-entitlement>=2.25.0,<2.26.0 ; extra == 'marketplace-entitlement'
+  - types-aiobotocore-marketplace-reporting>=2.25.0,<2.26.0 ; extra == 'marketplace-reporting'
+  - types-aiobotocore-marketplacecommerceanalytics>=2.25.0,<2.26.0 ; extra == 'marketplacecommerceanalytics'
+  - types-aiobotocore-mediaconnect>=2.25.0,<2.26.0 ; extra == 'mediaconnect'
+  - types-aiobotocore-mediaconvert>=2.25.0,<2.26.0 ; extra == 'mediaconvert'
+  - types-aiobotocore-medialive>=2.25.0,<2.26.0 ; extra == 'medialive'
+  - types-aiobotocore-mediapackage>=2.25.0,<2.26.0 ; extra == 'mediapackage'
+  - types-aiobotocore-mediapackage-vod>=2.25.0,<2.26.0 ; extra == 'mediapackage-vod'
+  - types-aiobotocore-mediapackagev2>=2.25.0,<2.26.0 ; extra == 'mediapackagev2'
+  - types-aiobotocore-mediastore>=2.25.0,<2.26.0 ; extra == 'mediastore'
+  - types-aiobotocore-mediastore-data>=2.25.0,<2.26.0 ; extra == 'mediastore-data'
+  - types-aiobotocore-mediatailor>=2.25.0,<2.26.0 ; extra == 'mediatailor'
+  - types-aiobotocore-medical-imaging>=2.25.0,<2.26.0 ; extra == 'medical-imaging'
+  - types-aiobotocore-memorydb>=2.25.0,<2.26.0 ; extra == 'memorydb'
+  - types-aiobotocore-meteringmarketplace>=2.25.0,<2.26.0 ; extra == 'meteringmarketplace'
+  - types-aiobotocore-mgh>=2.25.0,<2.26.0 ; extra == 'mgh'
+  - types-aiobotocore-mgn>=2.25.0,<2.26.0 ; extra == 'mgn'
+  - types-aiobotocore-migration-hub-refactor-spaces>=2.25.0,<2.26.0 ; extra == 'migration-hub-refactor-spaces'
+  - types-aiobotocore-migrationhub-config>=2.25.0,<2.26.0 ; extra == 'migrationhub-config'
+  - types-aiobotocore-migrationhuborchestrator>=2.25.0,<2.26.0 ; extra == 'migrationhuborchestrator'
+  - types-aiobotocore-migrationhubstrategy>=2.25.0,<2.26.0 ; extra == 'migrationhubstrategy'
+  - types-aiobotocore-mpa>=2.25.0,<2.26.0 ; extra == 'mpa'
+  - types-aiobotocore-mq>=2.25.0,<2.26.0 ; extra == 'mq'
+  - types-aiobotocore-mturk>=2.25.0,<2.26.0 ; extra == 'mturk'
+  - types-aiobotocore-mwaa>=2.25.0,<2.26.0 ; extra == 'mwaa'
+  - types-aiobotocore-neptune>=2.25.0,<2.26.0 ; extra == 'neptune'
+  - types-aiobotocore-neptune-graph>=2.25.0,<2.26.0 ; extra == 'neptune-graph'
+  - types-aiobotocore-neptunedata>=2.25.0,<2.26.0 ; extra == 'neptunedata'
+  - types-aiobotocore-network-firewall>=2.25.0,<2.26.0 ; extra == 'network-firewall'
+  - types-aiobotocore-networkflowmonitor>=2.25.0,<2.26.0 ; extra == 'networkflowmonitor'
+  - types-aiobotocore-networkmanager>=2.25.0,<2.26.0 ; extra == 'networkmanager'
+  - types-aiobotocore-networkmonitor>=2.25.0,<2.26.0 ; extra == 'networkmonitor'
+  - types-aiobotocore-notifications>=2.25.0,<2.26.0 ; extra == 'notifications'
+  - types-aiobotocore-notificationscontacts>=2.25.0,<2.26.0 ; extra == 'notificationscontacts'
+  - types-aiobotocore-oam>=2.25.0,<2.26.0 ; extra == 'oam'
+  - types-aiobotocore-observabilityadmin>=2.25.0,<2.26.0 ; extra == 'observabilityadmin'
+  - types-aiobotocore-odb>=2.25.0,<2.26.0 ; extra == 'odb'
+  - types-aiobotocore-omics>=2.25.0,<2.26.0 ; extra == 'omics'
+  - types-aiobotocore-opensearch>=2.25.0,<2.26.0 ; extra == 'opensearch'
+  - types-aiobotocore-opensearchserverless>=2.25.0,<2.26.0 ; extra == 'opensearchserverless'
+  - types-aiobotocore-organizations>=2.25.0,<2.26.0 ; extra == 'organizations'
+  - types-aiobotocore-osis>=2.25.0,<2.26.0 ; extra == 'osis'
+  - types-aiobotocore-outposts>=2.25.0,<2.26.0 ; extra == 'outposts'
+  - types-aiobotocore-panorama>=2.25.0,<2.26.0 ; extra == 'panorama'
+  - types-aiobotocore-partnercentral-selling>=2.25.0,<2.26.0 ; extra == 'partnercentral-selling'
+  - types-aiobotocore-payment-cryptography>=2.25.0,<2.26.0 ; extra == 'payment-cryptography'
+  - types-aiobotocore-payment-cryptography-data>=2.25.0,<2.26.0 ; extra == 'payment-cryptography-data'
+  - types-aiobotocore-pca-connector-ad>=2.25.0,<2.26.0 ; extra == 'pca-connector-ad'
+  - types-aiobotocore-pca-connector-scep>=2.25.0,<2.26.0 ; extra == 'pca-connector-scep'
+  - types-aiobotocore-pcs>=2.25.0,<2.26.0 ; extra == 'pcs'
+  - types-aiobotocore-personalize>=2.25.0,<2.26.0 ; extra == 'personalize'
+  - types-aiobotocore-personalize-events>=2.25.0,<2.26.0 ; extra == 'personalize-events'
+  - types-aiobotocore-personalize-runtime>=2.25.0,<2.26.0 ; extra == 'personalize-runtime'
+  - types-aiobotocore-pi>=2.25.0,<2.26.0 ; extra == 'pi'
+  - types-aiobotocore-pinpoint>=2.25.0,<2.26.0 ; extra == 'pinpoint'
+  - types-aiobotocore-pinpoint-email>=2.25.0,<2.26.0 ; extra == 'pinpoint-email'
+  - types-aiobotocore-pinpoint-sms-voice>=2.25.0,<2.26.0 ; extra == 'pinpoint-sms-voice'
+  - types-aiobotocore-pinpoint-sms-voice-v2>=2.25.0,<2.26.0 ; extra == 'pinpoint-sms-voice-v2'
+  - types-aiobotocore-pipes>=2.25.0,<2.26.0 ; extra == 'pipes'
+  - types-aiobotocore-polly>=2.25.0,<2.26.0 ; extra == 'polly'
+  - types-aiobotocore-pricing>=2.25.0,<2.26.0 ; extra == 'pricing'
+  - types-aiobotocore-proton>=2.25.0,<2.26.0 ; extra == 'proton'
+  - types-aiobotocore-qapps>=2.25.0,<2.26.0 ; extra == 'qapps'
+  - types-aiobotocore-qbusiness>=2.25.0,<2.26.0 ; extra == 'qbusiness'
+  - types-aiobotocore-qconnect>=2.25.0,<2.26.0 ; extra == 'qconnect'
+  - types-aiobotocore-quicksight>=2.25.0,<2.26.0 ; extra == 'quicksight'
+  - types-aiobotocore-ram>=2.25.0,<2.26.0 ; extra == 'ram'
+  - types-aiobotocore-rbin>=2.25.0,<2.26.0 ; extra == 'rbin'
+  - types-aiobotocore-rds>=2.25.0,<2.26.0 ; extra == 'rds'
+  - types-aiobotocore-rds-data>=2.25.0,<2.26.0 ; extra == 'rds-data'
+  - types-aiobotocore-redshift>=2.25.0,<2.26.0 ; extra == 'redshift'
+  - types-aiobotocore-redshift-data>=2.25.0,<2.26.0 ; extra == 'redshift-data'
+  - types-aiobotocore-redshift-serverless>=2.25.0,<2.26.0 ; extra == 'redshift-serverless'
+  - types-aiobotocore-rekognition>=2.25.0,<2.26.0 ; extra == 'rekognition'
+  - types-aiobotocore-repostspace>=2.25.0,<2.26.0 ; extra == 'repostspace'
+  - types-aiobotocore-resiliencehub>=2.25.0,<2.26.0 ; extra == 'resiliencehub'
+  - types-aiobotocore-resource-explorer-2>=2.25.0,<2.26.0 ; extra == 'resource-explorer-2'
+  - types-aiobotocore-resource-groups>=2.25.0,<2.26.0 ; extra == 'resource-groups'
+  - types-aiobotocore-resourcegroupstaggingapi>=2.25.0,<2.26.0 ; extra == 'resourcegroupstaggingapi'
+  - types-aiobotocore-rolesanywhere>=2.25.0,<2.26.0 ; extra == 'rolesanywhere'
+  - types-aiobotocore-route53>=2.25.0,<2.26.0 ; extra == 'route53'
+  - types-aiobotocore-route53-recovery-cluster>=2.25.0,<2.26.0 ; extra == 'route53-recovery-cluster'
+  - types-aiobotocore-route53-recovery-control-config>=2.25.0,<2.26.0 ; extra == 'route53-recovery-control-config'
+  - types-aiobotocore-route53-recovery-readiness>=2.25.0,<2.26.0 ; extra == 'route53-recovery-readiness'
+  - types-aiobotocore-route53domains>=2.25.0,<2.26.0 ; extra == 'route53domains'
+  - types-aiobotocore-route53profiles>=2.25.0,<2.26.0 ; extra == 'route53profiles'
+  - types-aiobotocore-route53resolver>=2.25.0,<2.26.0 ; extra == 'route53resolver'
+  - types-aiobotocore-rtbfabric>=2.25.0,<2.26.0 ; extra == 'rtbfabric'
+  - types-aiobotocore-rum>=2.25.0,<2.26.0 ; extra == 'rum'
+  - types-aiobotocore-s3>=2.25.0,<2.26.0 ; extra == 's3'
+  - types-aiobotocore-s3control>=2.25.0,<2.26.0 ; extra == 's3control'
+  - types-aiobotocore-s3outposts>=2.25.0,<2.26.0 ; extra == 's3outposts'
+  - types-aiobotocore-s3tables>=2.25.0,<2.26.0 ; extra == 's3tables'
+  - types-aiobotocore-s3vectors>=2.25.0,<2.26.0 ; extra == 's3vectors'
+  - types-aiobotocore-sagemaker>=2.25.0,<2.26.0 ; extra == 'sagemaker'
+  - types-aiobotocore-sagemaker-a2i-runtime>=2.25.0,<2.26.0 ; extra == 'sagemaker-a2i-runtime'
+  - types-aiobotocore-sagemaker-edge>=2.25.0,<2.26.0 ; extra == 'sagemaker-edge'
+  - types-aiobotocore-sagemaker-featurestore-runtime>=2.25.0,<2.26.0 ; extra == 'sagemaker-featurestore-runtime'
+  - types-aiobotocore-sagemaker-geospatial>=2.25.0,<2.26.0 ; extra == 'sagemaker-geospatial'
+  - types-aiobotocore-sagemaker-metrics>=2.25.0,<2.26.0 ; extra == 'sagemaker-metrics'
+  - types-aiobotocore-sagemaker-runtime>=2.25.0,<2.26.0 ; extra == 'sagemaker-runtime'
+  - types-aiobotocore-savingsplans>=2.25.0,<2.26.0 ; extra == 'savingsplans'
+  - types-aiobotocore-scheduler>=2.25.0,<2.26.0 ; extra == 'scheduler'
+  - types-aiobotocore-schemas>=2.25.0,<2.26.0 ; extra == 'schemas'
+  - types-aiobotocore-sdb>=2.25.0,<2.26.0 ; extra == 'sdb'
+  - types-aiobotocore-secretsmanager>=2.25.0,<2.26.0 ; extra == 'secretsmanager'
+  - types-aiobotocore-security-ir>=2.25.0,<2.26.0 ; extra == 'security-ir'
+  - types-aiobotocore-securityhub>=2.25.0,<2.26.0 ; extra == 'securityhub'
+  - types-aiobotocore-securitylake>=2.25.0,<2.26.0 ; extra == 'securitylake'
+  - types-aiobotocore-serverlessrepo>=2.25.0,<2.26.0 ; extra == 'serverlessrepo'
+  - types-aiobotocore-service-quotas>=2.25.0,<2.26.0 ; extra == 'service-quotas'
+  - types-aiobotocore-servicecatalog>=2.25.0,<2.26.0 ; extra == 'servicecatalog'
+  - types-aiobotocore-servicecatalog-appregistry>=2.25.0,<2.26.0 ; extra == 'servicecatalog-appregistry'
+  - types-aiobotocore-servicediscovery>=2.25.0,<2.26.0 ; extra == 'servicediscovery'
+  - types-aiobotocore-ses>=2.25.0,<2.26.0 ; extra == 'ses'
+  - types-aiobotocore-sesv2>=2.25.0,<2.26.0 ; extra == 'sesv2'
+  - types-aiobotocore-shield>=2.25.0,<2.26.0 ; extra == 'shield'
+  - types-aiobotocore-signer>=2.25.0,<2.26.0 ; extra == 'signer'
+  - types-aiobotocore-simspaceweaver>=2.25.0,<2.26.0 ; extra == 'simspaceweaver'
+  - types-aiobotocore-snow-device-management>=2.25.0,<2.26.0 ; extra == 'snow-device-management'
+  - types-aiobotocore-snowball>=2.25.0,<2.26.0 ; extra == 'snowball'
+  - types-aiobotocore-sns>=2.25.0,<2.26.0 ; extra == 'sns'
+  - types-aiobotocore-socialmessaging>=2.25.0,<2.26.0 ; extra == 'socialmessaging'
+  - types-aiobotocore-sqs>=2.25.0,<2.26.0 ; extra == 'sqs'
+  - types-aiobotocore-ssm>=2.25.0,<2.26.0 ; extra == 'ssm'
+  - types-aiobotocore-ssm-contacts>=2.25.0,<2.26.0 ; extra == 'ssm-contacts'
+  - types-aiobotocore-ssm-guiconnect>=2.25.0,<2.26.0 ; extra == 'ssm-guiconnect'
+  - types-aiobotocore-ssm-incidents>=2.25.0,<2.26.0 ; extra == 'ssm-incidents'
+  - types-aiobotocore-ssm-quicksetup>=2.25.0,<2.26.0 ; extra == 'ssm-quicksetup'
+  - types-aiobotocore-ssm-sap>=2.25.0,<2.26.0 ; extra == 'ssm-sap'
+  - types-aiobotocore-sso>=2.25.0,<2.26.0 ; extra == 'sso'
+  - types-aiobotocore-sso-admin>=2.25.0,<2.26.0 ; extra == 'sso-admin'
+  - types-aiobotocore-sso-oidc>=2.25.0,<2.26.0 ; extra == 'sso-oidc'
+  - types-aiobotocore-stepfunctions>=2.25.0,<2.26.0 ; extra == 'stepfunctions'
+  - types-aiobotocore-storagegateway>=2.25.0,<2.26.0 ; extra == 'storagegateway'
+  - types-aiobotocore-sts>=2.25.0,<2.26.0 ; extra == 'sts'
+  - types-aiobotocore-supplychain>=2.25.0,<2.26.0 ; extra == 'supplychain'
+  - types-aiobotocore-support>=2.25.0,<2.26.0 ; extra == 'support'
+  - types-aiobotocore-support-app>=2.25.0,<2.26.0 ; extra == 'support-app'
+  - types-aiobotocore-swf>=2.25.0,<2.26.0 ; extra == 'swf'
+  - types-aiobotocore-synthetics>=2.25.0,<2.26.0 ; extra == 'synthetics'
+  - types-aiobotocore-taxsettings>=2.25.0,<2.26.0 ; extra == 'taxsettings'
+  - types-aiobotocore-textract>=2.25.0,<2.26.0 ; extra == 'textract'
+  - types-aiobotocore-timestream-influxdb>=2.25.0,<2.26.0 ; extra == 'timestream-influxdb'
+  - types-aiobotocore-timestream-query>=2.25.0,<2.26.0 ; extra == 'timestream-query'
+  - types-aiobotocore-timestream-write>=2.25.0,<2.26.0 ; extra == 'timestream-write'
+  - types-aiobotocore-tnb>=2.25.0,<2.26.0 ; extra == 'tnb'
+  - types-aiobotocore-transcribe>=2.25.0,<2.26.0 ; extra == 'transcribe'
+  - types-aiobotocore-transfer>=2.25.0,<2.26.0 ; extra == 'transfer'
+  - types-aiobotocore-translate>=2.25.0,<2.26.0 ; extra == 'translate'
+  - types-aiobotocore-trustedadvisor>=2.25.0,<2.26.0 ; extra == 'trustedadvisor'
+  - types-aiobotocore-verifiedpermissions>=2.25.0,<2.26.0 ; extra == 'verifiedpermissions'
+  - types-aiobotocore-voice-id>=2.25.0,<2.26.0 ; extra == 'voice-id'
+  - types-aiobotocore-vpc-lattice>=2.25.0,<2.26.0 ; extra == 'vpc-lattice'
+  - types-aiobotocore-waf>=2.25.0,<2.26.0 ; extra == 'waf'
+  - types-aiobotocore-waf-regional>=2.25.0,<2.26.0 ; extra == 'waf-regional'
+  - types-aiobotocore-wafv2>=2.25.0,<2.26.0 ; extra == 'wafv2'
+  - types-aiobotocore-wellarchitected>=2.25.0,<2.26.0 ; extra == 'wellarchitected'
+  - types-aiobotocore-wisdom>=2.25.0,<2.26.0 ; extra == 'wisdom'
+  - types-aiobotocore-workdocs>=2.25.0,<2.26.0 ; extra == 'workdocs'
+  - types-aiobotocore-workmail>=2.25.0,<2.26.0 ; extra == 'workmail'
+  - types-aiobotocore-workmailmessageflow>=2.25.0,<2.26.0 ; extra == 'workmailmessageflow'
+  - types-aiobotocore-workspaces>=2.25.0,<2.26.0 ; extra == 'workspaces'
+  - types-aiobotocore-workspaces-instances>=2.25.0,<2.26.0 ; extra == 'workspaces-instances'
+  - types-aiobotocore-workspaces-thin-client>=2.25.0,<2.26.0 ; extra == 'workspaces-thin-client'
+  - types-aiobotocore-workspaces-web>=2.25.0,<2.26.0 ; extra == 'workspaces-web'
+  - types-aiobotocore-xray>=2.25.0,<2.26.0 ; extra == 'xray'
+  requires_python: '>=3.8'

--- a/src/parselmouth/cli/cli.py
+++ b/src/parselmouth/cli/cli.py
@@ -1,18 +1,18 @@
 from typing import Annotated, Optional
+
 import typer
 
-
-from parselmouth.internals.updater_producer import main as updater_producer_main
-from parselmouth.internals.updater import main as updater_main
+from parselmouth.explorer import explore_package
+from parselmouth.internals.channels import SupportedChannels
 from parselmouth.internals.check_one import main as check_one_main
-from parselmouth.internals.updater_merger import main as update_merger_main
+from parselmouth.internals.deleter import delete_main
 from parselmouth.internals.legacy_mapping import main as legacy_mapping_main
 from parselmouth.internals.mapping_transformer import main as mapping_transformer_main
 from parselmouth.internals.relations_updater import main as relations_updater_main
 from parselmouth.internals.remover import main as remover_main
-from parselmouth.explorer import explore_package
-
-from parselmouth.internals.channels import SupportedChannels
+from parselmouth.internals.updater import main as updater_main
+from parselmouth.internals.updater_merger import main as update_merger_main
+from parselmouth.internals.updater_producer import main as updater_producer_main
 
 app = typer.Typer(no_args_is_help=True, pretty_exceptions_enable=False)
 
@@ -210,6 +210,41 @@ def remove(
 
 
 @app.command()
+def delete(
+    names: Annotated[
+        list[str],
+        typer.Argument(
+            help="Conda package names whose records to remove from the index."
+        ),
+    ],
+    channel: SupportedChannels = SupportedChannels.CONDA_FORGE,
+    subdir: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--subdir",
+            help="Limit to specific subdirs (repeatable). Defaults to all subdirs.",
+        ),
+    ] = None,
+    dry_run: bool = True,
+):
+    """
+    Delete existing mapping records for the given conda package names from R2
+    and the channel index, forcing the next updater run to re-extract them
+    with current extraction logic.
+
+    Use this after fixing a bug in mapping extraction (e.g. a change to
+    `extract_artifact_mapping`) that has removed previously-stored
+    records.
+    """
+    delete_main(
+        names=names,
+        channel=channel,
+        subdirs=subdir,
+        dry_run=dry_run,
+    )
+
+
+@app.command()
 def explore(
     channel: SupportedChannels = SupportedChannels.CONDA_FORGE,
     endpoint: str = typer.Option(
@@ -351,8 +386,9 @@ def cache_info():
 
     Displays cache location, size, and metadata for all cached index files.
     """
-    from parselmouth.explorer.index_cache import get_cache_dir, get_cache_info
     from datetime import datetime
+
+    from parselmouth.explorer.index_cache import get_cache_dir, get_cache_info
 
     cache_dir = get_cache_dir()
     typer.echo(f"\n📁 Cache directory: {cache_dir}\n")

--- a/src/parselmouth/internals/artifact.py
+++ b/src/parselmouth/internals/artifact.py
@@ -1,19 +1,28 @@
-from pathlib import Path
-import re
-from packaging.version import parse
-from parselmouth.internals.utils import normalize
-from typing import Optional
-from conda_forge_metadata.types import ArtifactData
 import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+from conda_forge_metadata.types import ArtifactData
+from packaging.version import parse
 
 from parselmouth.internals.s3 import MappingEntry
-
+from parselmouth.internals.utils import normalize
 
 dist_info_pattern = r"([^/]+)-(\d+[^/]*)\.dist-info\/METADATA"
 egg_info_pattern = r"([^/]+?)-(\d+[^/]*)\.egg-info\/PKG-INFO"
 
 dist_pattern_compiled = re.compile(dist_info_pattern)
 egg_pattern_compiled = re.compile(egg_info_pattern)
+
+# Matches paths that start with one of the three canonical site-packages
+# locations of a conda environment:
+#   - "site-packages/"                        (noarch packages)
+#   - "lib/pythonX.Y/site-packages/"          (Linux / macOS)
+#   - "Lib/site-packages/"                    (Windows)
+site_packages_prefix_pattern = re.compile(
+    r"^(?:site-packages|lib/python\d+(?:\.\d+)?/site-packages|Lib/site-packages)/"
+)
 
 
 def check_if_is_direct_url(package_name: str, url: Optional[str]) -> bool:
@@ -44,6 +53,12 @@ def get_pypi_names_and_version(files: list[str]) -> dict[str, str]:
     package_names: dict[str, str] = {}
     for file_name in files:
         file_path = Path(file_name)
+        # Reject anything outside the conda environment's own site-packages,
+        # e.g. a bundled Python shipped under share/.../bundledpythonunix/.
+        # Those dist-info entries belong to a private interpreter and must
+        # not be advertised as PyPI names provided by the conda package.
+        if not site_packages_prefix_pattern.match(file_name):
+            continue
         # sometimes, packages like setuptools have some stuff vendored
         # that our regex will catch:
         # site-packages/setuptools/_vendor/zipp-3.19.2.dist-info/RECORD

--- a/src/parselmouth/internals/deleter.py
+++ b/src/parselmouth/internals/deleter.py
@@ -1,0 +1,70 @@
+"""
+One-shot invalidation of mapping records by conda package name.
+"""
+
+import asyncio
+import logging
+from typing import Optional
+
+from parselmouth.internals.channels import SupportedChannels
+from parselmouth.internals.conda_forge import get_all_packages_by_subdir
+from parselmouth.internals.remover import remove_from_s3
+from parselmouth.internals.s3 import s3_client
+from parselmouth.internals.subdirs import DEFAULT_SUBDIRS
+
+
+def delete_main(
+    names: list[str],
+    channel: SupportedChannels = SupportedChannels.CONDA_FORGE,
+    subdirs: Optional[list[str]] = None,
+    dry_run: bool = True,
+) -> None:
+    """
+    Delete existing mapping records for the given conda package `names` from
+    R2 and drop them from the channel index, so the next updater run
+    re-extracts them.
+    """
+    target_names = set(names)
+    target_subdirs = subdirs if subdirs else DEFAULT_SUBDIRS
+
+    existing_mapping_data = s3_client.get_channel_index(channel=channel)
+    assert existing_mapping_data, f"No index found for channel {channel}"
+
+    sha_to_remove: list[str] = []
+
+    for subdir in target_subdirs:
+        try:
+            repodatas = get_all_packages_by_subdir(subdir, channel)
+        except Exception as e:
+            logging.warning(f"Could not fetch repodata for {subdir} on {channel}: {e}")
+            continue
+
+        for _label, packages in repodatas.items():
+            for _filename, package in packages.items():
+                if package.get("name") not in target_names:
+                    continue
+                sha256 = package.get("sha256")
+                if not sha256:
+                    continue
+                if sha256 in existing_mapping_data.root:
+                    sha_to_remove.append(sha256)
+
+    logging.warning(
+        f"Found {len(sha_to_remove)} mapping records to delete for "
+        f"names={sorted(target_names)} on channel {channel}"
+    )
+
+    if dry_run:
+        logging.warning("Dry-run: not deleting anything")
+        return
+
+    asyncio.run(remove_from_s3(sha_to_remove))
+
+    for sha in sha_to_remove:
+        existing_mapping_data.root.pop(sha, None)
+    s3_client.upload_index(existing_mapping_data, channel=channel)
+
+    logging.warning(
+        f"Deleted {len(sha_to_remove)} records on {channel}; "
+        "next updater run will re-extract them."
+    )

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -1,0 +1,53 @@
+from parselmouth.internals.artifact import get_pypi_names_and_version
+
+
+def test_linux_dist_info():
+    files = ["lib/python3.13/site-packages/numpy-2.0.0.dist-info/METADATA"]
+    assert get_pypi_names_and_version(files) == {"numpy": "2.0.0"}
+
+
+def test_noarch_dist_info():
+    files = ["site-packages/foo-1.0.0.dist-info/METADATA"]
+    assert get_pypi_names_and_version(files) == {"foo": "1.0.0"}
+
+
+def test_windows_dist_info():
+    files = ["Lib/site-packages/foo-1.0.0.dist-info/METADATA"]
+    assert get_pypi_names_and_version(files) == {"foo": "1.0.0"}
+
+
+def test_egg_info_in_site_packages():
+    files = ["lib/python3.10/site-packages/foo-1.2.3.egg-info/PKG-INFO"]
+    assert get_pypi_names_and_version(files) == {"foo": "1.2.3"}
+
+
+def test_setuptools_vendor_excluded():
+    files = [
+        "lib/python3.13/site-packages/setuptools-75.0.0.dist-info/METADATA",
+        "lib/python3.13/site-packages/setuptools/_vendor/zipp-3.19.2.dist-info/METADATA",
+    ]
+    assert get_pypi_names_and_version(files) == {"setuptools": "75.0.0"}
+
+
+def test_bundled_python_excluded_regression_5917():
+    """google-cloud-sdk ships a full bundled CPython under
+    share/.../bundledpythonunix/. Its dist-info entries must not be reported
+    as PyPI names provided by the conda package.
+
+    Regression test for https://github.com/prefix-dev/pixi/issues/5917.
+    """
+    files = [
+        "share/google-cloud-sdk-565.0.0-0/platform/bundledpythonunix/lib/python3.13/site-packages/grpcio-1.80.0.dist-info/METADATA",
+        "share/google-cloud-sdk-565.0.0-0/platform/bundledpythonunix/lib/python3.13/site-packages/cryptography-43.0.1.dist-info/METADATA",
+        "share/google-cloud-sdk-565.0.0-0/platform/bundledpythonunix/lib/python3.13/site-packages/cffi-1.17.1.dist-info/METADATA",
+    ]
+    assert get_pypi_names_and_version(files) == {}
+
+
+def test_mixed_real_and_bundled():
+    files = [
+        "lib/python3.12/site-packages/realpkg-1.0.0.dist-info/METADATA",
+        "share/some-tool/platform/bundledpythonunix/lib/python3.13/site-packages/grpcio-1.80.0.dist-info/METADATA",
+        "opt/some-app/python/site-packages/other-2.0.0.dist-info/METADATA",
+    ]
+    assert get_pypi_names_and_version(files) == {"realpkg": "1.0.0"}


### PR DESCRIPTION
This should exclude more vendored packages from the mapping and adds a command for removing the package so it will be recreated.

This change was motivated because we still are mapping the incorrect things: https://github.com/prefix-dev/pixi/issues/5917