### PR TITLE
fix(mapping_transformer): union pypi_names across artifacts instead of overwriting

### DIFF
--- a/src/parselmouth/internals/mapping_transformer.py
+++ b/src/parselmouth/internals/mapping_transformer.py
@@ -57,20 +57,17 @@ def transform_mapping_and_save(
         pypi_names = mapping.pypi_normalized_names
 
         if conda_name in compressed_mapping:
-            existing_pypi = compressed_mapping[conda_name].pypi_names
-
-            if existing_pypi != pypi_names:
-                # sometimes mapping don't have path
-                # a good example is
-                # aesara-2.0.0-py36hb100763_0.tar.bz2 will have paths
-                # and aesara-2.7.4-py310hd84b9e8_1.tar.bz2 will not
-
-                if pypi_names:
-                    # sometimes and older version of package has a broken path to dist_info or egg_info
-                    # here we overwrite the newer one with that old and broken
-                    compressed_mapping[conda_name] = CompressedMapping(
-                        pypi_names=pypi_names
-                    )
+            # Different builds of the same conda package can map to
+            # different PyPI distribution names — e.g. some `open3d`
+            # builds map to `open3d` on PyPI, others to `open3d-cpu`.
+            # Take the union so every PyPI name observed across any
+            # build is preserved.
+            existing_pypi = set(compressed_mapping[conda_name].pypi_names or [])
+            new_pypi = set(pypi_names or [])
+            merged = sorted(existing_pypi | new_pypi)
+            compressed_mapping[conda_name] = CompressedMapping(
+                pypi_names=merged or None,
+            )
 
         else:
             # previously we didn't recorded packages that didn't have pypi name


### PR DESCRIPTION
The conda `open3d` package bundles dist-info for both `open3d` and `open3d-cpu`. The per-artifact loop in `mapping_transformer.py` overwrote `pypi_names` whenever a later artifact had a different list, so the compressed mapping kept only one of them depending on iteration order.

**Before**
```json
"open3d": ["open3d"]
```

**After**
```json
"open3d": ["open3d", "open3d-cpu"]
```

Union across artifacts instead of overwriting.

## Test plan
- [x] `pixi run -e test test` — 30 passed
- [ ] After merge: next hourly `update_channel_v0_v1` regenerates `files/v0/conda-forge/compressed_mapping.json`; verify `open3d` is `["open3d", "open3d-cpu"]`