### PR TITLE
Fix CI: commit frontend/src/lib (un-ignored from .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!/frontend/src/lib/
 lib64/
 parts/
 sdist/

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "./utils";
+import { normalizePypi } from "./pypi";
+
+export type Channel = "conda-forge" | "bioconda";
+
+export const CHANNELS: { value: Channel; label: string }[] = [
+  { value: "conda-forge", label: "conda-forge" },
+  { value: "bioconda", label: "bioconda" },
+];
+
+/**
+ * Raw conda → pypi name mapping shipped from the parselmouth repo at
+ * files/v0/{channel}/compressed_mapping.json. Conda names that have no
+ * known PyPI counterpart map to `null`. ~925 KB raw / ~190 KB gzipped
+ * for conda-forge.
+ *
+ * The frontend derives both the autocomplete name index and the
+ * conda→pypi pairs index from this single source in memory.
+ */
+export type CompressedMapping = Record<string, string[] | null>;
+
+/**
+ * pypi-to-conda-v1 file shape on R2. The live format has `conda_versions`
+ * values as a single conda-name string; older docs show arrays for
+ * vendoring cases — we accept both.
+ */
+export interface PypiToCondaDetail {
+  format_version?: string;
+  channel?: string;
+  pypi_name: string;
+  conda_versions: Record<string, string | string[]>;
+}
+
+export function condaNamesFor(value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+// raw.githubusercontent.com sends CORS headers, so production fetches go direct.
+// In dev we proxy through /api/gh to keep things same-origin and quiet.
+const GH_BASE = import.meta.env.DEV
+  ? "/api/gh"
+  : "https://raw.githubusercontent.com";
+
+const REPO_PATH = "prefix-dev/parselmouth/main/files/v0";
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText} – ${url}`);
+  }
+  return (await res.json()) as T;
+}
+
+export function useCompressedMapping(channel: Channel) {
+  return useQuery({
+    queryKey: ["compressed-mapping", channel],
+    queryFn: () =>
+      fetchJson<CompressedMapping>(
+        `${GH_BASE}/${REPO_PATH}/${channel}/compressed_mapping.json`,
+      ),
+  });
+}
+
+export function usePypiDetail(channel: Channel, pypiName: string | null) {
+  return useQuery({
+    enabled: !!pypiName,
+    queryKey: ["pypi-detail", channel, pypiName],
+    queryFn: () => {
+      const normalized = normalizePypi(pypiName!);
+      return fetchJson<PypiToCondaDetail>(
+        `${API_BASE}/pypi-to-conda-v1/${channel}/${normalized}.json`,
+      );
+    },
+  });
+}

--- a/frontend/src/lib/names.ts
+++ b/frontend/src/lib/names.ts
@@ -1,0 +1,151 @@
+import Fuse from "fuse.js";
+import { useMemo } from "react";
+import { useCompressedMapping, type Channel, type CompressedMapping } from "./api";
+
+export type Side = "conda" | "pypi";
+
+export interface SearchHit {
+  side: Side;
+  name: string;
+}
+
+export interface DerivedIndex {
+  /** Conda → list of PyPI names (nulls dropped). */
+  pairs: Record<string, string[]>;
+  /** Reverse lookup: PyPI name → conda packages that ship it. */
+  reverse: Record<string, string[]>;
+  /** Fast existence checks. */
+  hasConda: Set<string>;
+  hasPypi: Set<string>;
+  condaCount: number;
+  pypiCount: number;
+}
+
+export interface NameSearcher extends DerivedIndex {
+  search(query: string, limit?: number): SearchHit[];
+}
+
+interface FuseEntry {
+  side: Side;
+  name: string;
+}
+
+const FUSE_OPTIONS: ConstructorParameters<typeof Fuse<FuseEntry>>[1] = {
+  keys: ["name"],
+  threshold: 0.3,
+  ignoreLocation: true,
+  minMatchCharLength: 2,
+  includeScore: true,
+};
+
+/**
+ * Build the derived indices from the raw compressed mapping.
+ * Cheap (~30 ms for conda-forge's 32k entries) — runs in a useMemo.
+ */
+export function deriveIndex(mapping: CompressedMapping): DerivedIndex {
+  // Prototype-less so package names like "constructor", "toString",
+  // "hasOwnProperty" don't collide with Object.prototype keys.
+  const pairs = Object.create(null) as Record<string, string[]>;
+  const reverse = Object.create(null) as Record<string, string[]>;
+  const pypiSet = new Set<string>();
+
+  for (const [condaName, pypis] of Object.entries(mapping)) {
+    if (!pypis || pypis.length === 0) continue;
+    pairs[condaName] = pypis;
+    for (const p of pypis) {
+      pypiSet.add(p);
+      const bucket = reverse[p];
+      if (bucket) {
+        bucket.push(condaName);
+      } else {
+        reverse[p] = [condaName];
+      }
+    }
+  }
+
+  return {
+    pairs,
+    reverse,
+    hasConda: new Set(Object.keys(mapping)),
+    hasPypi: pypiSet,
+    condaCount: Object.keys(mapping).length,
+    pypiCount: pypiSet.size,
+  };
+}
+
+/**
+ * Hook: fetch compressed mapping (cached by TanStack Query across consumers)
+ * and derive the index. Cheap re-derivation is fine; only one fetch happens
+ * per channel.
+ */
+export function useDerivedIndex(channel: Channel) {
+  const query = useCompressedMapping(channel);
+  const index = useMemo(
+    () => (query.data ? deriveIndex(query.data) : null),
+    [query.data],
+  );
+  return { ...query, index };
+}
+
+/**
+ * Hook: same fetch as useDerivedIndex, plus a Fuse fuzzy-search index on top.
+ * The Fuse construction is only paid by consumers that need search.
+ */
+export function useNameSearcher(channel: Channel): NameSearcher | null {
+  const { data, index } = useDerivedIndex(channel);
+  return useMemo(() => {
+    if (!data || !index) return null;
+    const entries: FuseEntry[] = [
+      ...Array.from(index.hasConda).map((name) => ({
+        side: "conda" as const,
+        name,
+      })),
+      ...Array.from(index.hasPypi).map((name) => ({
+        side: "pypi" as const,
+        name,
+      })),
+    ];
+    const fuse = new Fuse(entries, FUSE_OPTIONS);
+
+    return {
+      ...index,
+      search(query, limit = 20) {
+        const trimmed = query.trim();
+        if (!trimmed) return [];
+
+        // Exact-match first so they lead the dropdown.
+        const exact: SearchHit[] = [];
+        if (index.hasConda.has(trimmed))
+          exact.push({ side: "conda", name: trimmed });
+        if (index.hasPypi.has(trimmed))
+          exact.push({ side: "pypi", name: trimmed });
+
+        const fuzzy = fuse
+          .search(trimmed, { limit: limit + exact.length })
+          .map((r) => ({ side: r.item.side, name: r.item.name }))
+          .filter((h) => h.name !== trimmed);
+
+        return [...exact, ...fuzzy].slice(0, limit);
+      },
+    };
+  }, [data, index]);
+}
+
+// Re-export so consumers can keep `import { type Channel } from "./names"` if convenient.
+export type { CompressedMapping };
+
+export function lookupCondaToPypi(
+  index: DerivedIndex | null | undefined,
+  condaName: string,
+): string[] | null {
+  if (!index) return null;
+  return index.pairs[condaName] ?? null;
+}
+
+export function lookupPypiToConda(
+  index: DerivedIndex | null | undefined,
+  pypiName: string,
+): string[] {
+  if (!index) return [];
+  return index.reverse[pypiName] ?? [];
+}

--- a/frontend/src/lib/pypi.ts
+++ b/frontend/src/lib/pypi.ts
@@ -1,0 +1,7 @@
+/**
+ * PEP 503 normalization: lowercase and collapse runs of `[-_.]` to a single `-`.
+ * https://peps.python.org/pep-0503/#normalized-names
+ */
+export function normalizePypi(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, "-");
+}

--- a/frontend/src/lib/urls.ts
+++ b/frontend/src/lib/urls.ts
@@ -1,0 +1,32 @@
+import type { Channel } from "./api";
+import { normalizePypi } from "./pypi";
+
+/**
+ * Canonical conda package page on prefix.dev.
+ * https://prefix.dev/channels/{channel}/packages/{name}
+ */
+export function condaPackageUrl(channel: Channel, condaName: string): string {
+  return `https://prefix.dev/channels/${channel}/packages/${encodeURIComponent(
+    condaName,
+  )}`;
+}
+
+/**
+ * PyPI project page. PyPI accepts both normalized and unnormalized names
+ * (it redirects), but linking with the PEP 503 normalized form skips that hop.
+ */
+export function pypiPackageUrl(pypiName: string): string {
+  return `https://pypi.org/project/${encodeURIComponent(
+    normalizePypi(pypiName),
+  )}/`;
+}
+
+/**
+ * PyPI project page at a specific release.
+ * https://pypi.org/project/{name}/{version}/
+ */
+export function pypiVersionUrl(pypiName: string, version: string): string {
+  return `https://pypi.org/project/${encodeURIComponent(
+    normalizePypi(pypiName),
+  )}/${encodeURIComponent(version)}/`;
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,9 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export const API_BASE: string =
+  (import.meta.env.VITE_API_BASE as string | undefined) ?? "/api/r2";


### PR DESCRIPTION
## Problem

The "Deploy frontend to GitHub Pages" workflow [failed](https://github.com/prefix-dev/parselmouth/actions/runs/26153333131/job/76926171051) with `TS2307: Cannot find module './lib/api'` (and `names`, `pypi`, `urls`).

## Root cause

The root `.gitignore` has a Python-packaging rule `lib/` that silently excluded `frontend/src/lib/`. The API/names/pypi/urls/utils modules existed locally but were never committed, so the Pages build couldn't resolve them. The implicit-`any` errors in the CI log were downstream of the missing modules.

## Fix

- Add a `!/frontend/src/lib/` negation to `.gitignore`.
- Commit the 5 missing modules: `api.ts`, `names.ts`, `pypi.ts`, `urls.ts`, `utils.ts`.

Verified locally: `tsc --noEmit && vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)