### PR TITLE
frontend: additional comments by jaime

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "^5.62.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.4",
+    "fastest-levenshtein": "^1.0.16",
     "fuse.js": "^7.0.0",
     "lucide-react": "^0.460.0",
     "react": "^18.3.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       cmdk:
         specifier: ^1.0.4
         version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      fastest-levenshtein:
+        specifier: ^1.0.16
+        version: 1.0.16
       fuse.js:
         specifier: ^7.0.0
         version: 7.3.0
@@ -546,66 +549,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -789,6 +805,10 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1817,6 +1837,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fastest-levenshtein@1.0.16: {}
 
   fastq@1.20.1:
     dependencies:

--- a/frontend/src/components/MappingDetail.tsx
+++ b/frontend/src/components/MappingDetail.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
-import { Check, ExternalLink, PackagePlus, Sparkles } from "lucide-react";
+import { useMemo, useState } from "react";
+import { distance as levenshteinDistance } from "fastest-levenshtein";
+import { Check, ChevronDown, ExternalLink, PackagePlus, Sparkles } from "lucide-react";
 import { type Channel } from "../lib/api";
 import {
   lookupCondaToPypi,
@@ -56,11 +57,29 @@ export function MappingDetail({
         : [];
     }
     const condaNames = lookupPypiToConda(index, primaryPypi);
-    return condaNames.map((c, i) => ({
-      name: c,
-      primary: side === "conda" ? c === name : i === 0,
-      context: side === "conda" && c === name ? "selected" : undefined,
-    }));
+    const directName = side === "conda" ? name : primaryPypi;
+    const items = condaNames.map((c, i) => {
+      const direct = c === directName;
+      return {
+        name: c,
+        primary: direct || (side === "pypi" && i === 0 && !condaNames.includes(directName)),
+        context:
+          side === "conda" && direct
+            ? "selected"
+            : side === "pypi" && direct
+              ? "name match"
+              : undefined,
+      };
+    });
+
+    // The reverse index is alphabetic by conda package name, which can bury the
+    // best answer (e.g. pypi::numpy after hist-base). Keep exact selected/direct
+    // matches first, then order the remaining observations by name similarity.
+    return items.sort((a, b) => {
+      const exactDelta = Number(b.name === directName) - Number(a.name === directName);
+      if (exactDelta !== 0) return exactDelta;
+      return nameDistance(a.name, directName) - nameDistance(b.name, directName);
+    });
   }, [index, primaryPypi, side, name]);
 
   const pypiList: ListItem[] = useMemo(() => {
@@ -124,6 +143,16 @@ export function MappingDetail({
           items={condaList}
           loading={loading && side === "pypi"}
           hrefFor={(n) => condaPackageUrl(channel, n)}
+          note={
+            primaryPypi
+              ? side === "conda"
+                ? `Selected package, plus other packages that also report PyPI metadata for ${primaryPypi}.`
+                : `Packages that report PyPI metadata for ${primaryPypi}.`
+              : undefined
+          }
+          collapseSecondary
+          secondaryLabel="other related conda packages"
+          secondaryHint="These packages contain metadata for this PyPI name, but may just include it as a dependency or bundled file; they are not necessarily aliases."
           emptyHint={
             side === "pypi"
               ? "No conda packages ship this PyPI name yet."
@@ -165,6 +194,18 @@ export function MappingDetail({
   );
 }
 
+function nameDistance(a: string, b: string): number {
+  const left = normalizePackageName(a);
+  const right = normalizePackageName(b);
+  if (left === right) return 0;
+
+  return levenshteinDistance(left, right) / Math.max(left.length, right.length, 1);
+}
+
+function normalizePackageName(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, "-");
+}
+
 function SideBadge({ kind }: { kind: Side }) {
   const tones =
     kind === "conda"
@@ -186,6 +227,10 @@ interface PackageCardProps {
   loading?: boolean;
   normalized?: { from: string; to: string } | null;
   emptyHint?: string;
+  note?: string;
+  collapseSecondary?: boolean;
+  secondaryLabel?: string;
+  secondaryHint?: string;
   hrefFor: (name: string) => string;
 }
 
@@ -195,13 +240,28 @@ function PackageCard({
   loading,
   normalized,
   emptyHint,
+  note,
+  collapseSecondary,
+  secondaryLabel = "other related packages",
+  secondaryHint,
   hrefFor,
 }: PackageCardProps) {
+  const [secondaryOpen, setSecondaryOpen] = useState(false);
   const title = kind === "conda" ? "Conda packages" : "PyPI packages";
   const head =
     kind === "conda"
       ? "border-b-conda-border bg-conda-bg-soft text-conda-ink"
       : "border-b-pypi-border bg-pypi-bg-soft text-pypi-ink";
+
+  const primaryItems = collapseSecondary ? items.filter((item) => item.primary) : items;
+  const secondaryItems = collapseSecondary
+    ? items.filter((item) => !item.primary)
+    : [];
+  const visibleItems = collapseSecondary
+    ? secondaryOpen
+      ? [...primaryItems, ...secondaryItems]
+      : primaryItems
+    : items;
 
   return (
     <div className="relative overflow-hidden rounded-2xl border border-rail bg-white shadow-card">
@@ -216,6 +276,11 @@ function PackageCard({
           {items.length} {items.length === 1 ? "name" : "names"}
         </span>
       </div>
+      {note && (
+        <div className="border-b border-rail bg-cream-50 px-4 py-2 text-[12.5px] leading-relaxed text-cream-600">
+          {note}
+        </div>
+      )}
       <div className="px-2 py-1.5">
         {loading && (
           <div className="px-2.5 py-2 text-[13px] text-cream-600">Loading…</div>
@@ -225,33 +290,37 @@ function PackageCard({
             {emptyHint ?? "—"}
           </div>
         )}
-        {items.map((item, i) => (
-          <a
+        {visibleItems.map((item, i) => (
+          <PackageRow
             key={item.name}
+            item={item}
+            index={i}
             href={hrefFor(item.name)}
-            target="_blank"
-            rel="noreferrer"
-            className={
-              "group flex items-center gap-2.5 rounded-md px-2.5 py-2 font-mono text-[13.5px] tracking-[-0.01em] no-underline hover:bg-cream-50 " +
-              (item.primary ? "text-ink font-medium" : "text-ink") +
-              (i > 0 ? " border-t border-dashed border-rail" : "")
-            }
-          >
-            <span className="w-3.5 text-right font-mono text-[11px] text-cream-400">
-              {i + 1}
-            </span>
-            <span>{item.name}</span>
-            <ExternalLink
-              size={12}
-              className="text-cream-300 opacity-0 transition-opacity group-hover:opacity-100"
-            />
-            {item.context && (
-              <span className="ml-auto font-mono text-[11.5px] text-cream-400">
-                {item.context}
-              </span>
-            )}
-          </a>
+          />
         ))}
+        {collapseSecondary && secondaryItems.length > 0 && (
+          <div className="border-t border-dashed border-rail px-2.5 py-2">
+            <button
+              type="button"
+              onClick={() => setSecondaryOpen((open) => !open)}
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-md text-[12.5px] font-medium text-cream-600 hover:text-ink"
+              aria-expanded={secondaryOpen}
+            >
+              <ChevronDown
+                size={14}
+                className={
+                  "transition-transform " + (secondaryOpen ? "rotate-180" : "")
+                }
+              />
+              {secondaryOpen ? "Hide" : "Show"} {secondaryItems.length} {secondaryLabel}
+            </button>
+            {secondaryHint && (
+              <p className="mt-1.5 max-w-[48ch] text-[11.5px] leading-relaxed text-cream-500">
+                {secondaryHint}
+              </p>
+            )}
+          </div>
+        )}
         {normalized && (
           <div className="px-2.5 pb-1 pt-2.5">
             <span className="inline-flex items-center gap-1.5 rounded-full border border-rail bg-cream-100 px-2 py-0.5 text-[11.5px] text-cream-600">
@@ -269,5 +338,42 @@ function PackageCard({
         )}
       </div>
     </div>
+  );
+}
+
+function PackageRow({
+  item,
+  index,
+  href,
+}: {
+  item: ListItem;
+  index: number;
+  href: string;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className={
+        "group flex items-center gap-2.5 rounded-md px-2.5 py-2 font-mono text-[13.5px] tracking-[-0.01em] no-underline hover:bg-cream-50 " +
+        (item.primary ? "text-ink font-medium" : "text-ink") +
+        (index > 0 ? " border-t border-dashed border-rail" : "")
+      }
+    >
+      <span className="w-3.5 text-right font-mono text-[11px] text-cream-400">
+        {index + 1}
+      </span>
+      <span>{item.name}</span>
+      <ExternalLink
+        size={12}
+        className="text-cream-300 opacity-0 transition-opacity group-hover:opacity-100"
+      />
+      {item.context && (
+        <span className="ml-auto rounded-full border border-rail bg-cream-50 px-1.5 py-0.5 font-sans text-[10.5px] font-semibold uppercase tracking-[0.05em] text-cream-600">
+          {item.context}
+        </span>
+      )}
+    </a>
   );
 }


### PR DESCRIPTION
Jaime had some comments:

> jaimergp: Lovely! Also nice that the raw JSONs behind are linkedjaimergp: A suggestions: I'm confused by the "conda packages" table showing other things than numpy when I searched for conda::numpy

> I assume those are conda packages that _also_ vendor pypi::numpy (accidentally or intentionally), but it's weird that it's sorted alphabetically. I'd highlight the selected choice in first row, and even hide the others behind a collapsible element.jaimergp: If you search for pypi::numpy, it's even worse because there's no "selected" row anymore: https://prefix-dev.github.io/parselmouth/?q=numpy&dir=pypijaimergp: I assume the data to resort is not available in the mapping, but there should be some criterion to not bag all of them in the same list (single package results are preferred; if they show up next to other packages, they are down-weighted)jaimergp: It's super nice to have this tool to explore the mappings so we can improve them, so thank you for sharing!

We cannot fix all of them but make the fronted a bit clearer at least, which we did:

<img width="2252" height="1172" alt="image" src="https://github.com/user-attachments/assets/a765798e-f85c-4a60-99cc-302fe5d8783e" />
