### PR TITLE
fix: match lowercase Windows site-packages

### DIFF
--- a/src/parselmouth/internals/artifact.py
+++ b/src/parselmouth/internals/artifact.py
@@ -19,9 +19,9 @@ egg_pattern_compiled = re.compile(egg_info_pattern)
 # locations of a conda environment:
 #   - "site-packages/"                        (noarch packages)
 #   - "lib/pythonX.Y/site-packages/"          (Linux / macOS)
-#   - "Lib/site-packages/"                    (Windows)
+#   - "Lib/site-packages/" or "lib/site-packages/" (Windows)
 site_packages_prefix_pattern = re.compile(
-    r"^(?:site-packages|lib/python\d+(?:\.\d+)?/site-packages|Lib/site-packages)/"
+    r"^(?:site-packages|lib/python\d+(?:\.\d+)?/site-packages|[Ll]ib/site-packages)/"
 )
 
 

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -16,6 +16,11 @@ def test_windows_dist_info():
     assert get_pypi_names_and_version(files) == {"foo": "1.0.0"}
 
 
+def test_windows_lowercase_lib_dist_info():
+    files = ["lib/site-packages/idyntree-15.1.0.dist-info/METADATA"]
+    assert get_pypi_names_and_version(files) == {"idyntree": "15.1.0"}
+
+
 def test_egg_info_in_site_packages():
     files = ["lib/python3.10/site-packages/foo-1.2.3.egg-info/PKG-INFO"]
     assert get_pypi_names_and_version(files) == {"foo": "1.2.3"}


### PR DESCRIPTION
Windows package archives can record their site-packages directory as lowercase `lib/site-packages/`. The current prefix filter only accepts `Lib/site-packages/`, so these artifacts are stored without a PyPI mapping. This is currently affecting the win-64 `idyntree-python` 15.1.0 builds.

This accepts either casing for the Windows root and adds a regression test using the actual idyntree path. The match remains anchored at the environment root, so bundled Python installations are still excluded.

## Testing

- `pixi run -e test pytest tests -q` — 31 passed
- Ruff check and format check

After this merges, the existing `idyntree-python` win-64 records still need to be invalidated so the normal updater can regenerate the hash, v1, and compressed mappings.

Fixes #80
